### PR TITLE
Fix ImageGallery initialisation code

### DIFF
--- a/assets/targets/components/gallery/01-default-gallery.slim
+++ b/assets/targets/components/gallery/01-default-gallery.slim
@@ -89,6 +89,8 @@ ul.image-gallery
       figure
         img src="#{asset_path('assets/images/gallery/thumbs/18.jpg')}" alt=""
         figcaption Lorem ipsum Proident do aute cupidatat enim.
+
+ul.image-gallery
   li.item
     a href="#{asset_path('assets/images/gallery/9.jpg')}" data-size="1500x1000"
       figure

--- a/assets/targets/components/index.js
+++ b/assets/targets/components/index.js
@@ -134,13 +134,13 @@ window.UOMloadComponents = function() {
       imagesLoaded = require('imagesloaded');
       ImageGallery = require("./gallery");
 
-      slingshot = function() {
-        new ImageGallery(g, {});
-      };
-
       for (i=recs.length - 1; i >= 0; i--) {
         g = recs[i];
-        imagesLoaded(g, slingshot);
+        imagesLoaded(g, (function(g) {
+          return function() {
+            new ImageGallery(g, {});
+          };
+        }(g)));
       }
     }
 

--- a/assets/targets/components/index.js
+++ b/assets/targets/components/index.js
@@ -131,16 +131,17 @@ window.UOMloadComponents = function() {
 
     recs = document.querySelectorAll('ul.image-gallery');
     if (recs.length > 0) {
-      imagesLoaded = require('imagesloaded');
+      imagesLoaded = require("imagesloaded");
       ImageGallery = require("./gallery");
+
+      slingshot = function() {
+        new ImageGallery(this, {});
+      };
 
       for (i=recs.length - 1; i >= 0; i--) {
         g = recs[i];
-        imagesLoaded(g, (function(g) {
-          return function() {
-            new ImageGallery(g, {});
-          };
-        }(g)));
+
+        imagesLoaded(g, slingshot.bind(g));
       }
     }
 

--- a/assets/targets/debranded/index.js
+++ b/assets/targets/debranded/index.js
@@ -133,13 +133,13 @@ window.DSComponentsLoad = function() {
     imagesLoaded = require('imagesloaded');
     ImageGallery = require("../components/gallery");
 
-    slingshot = function() {
-      new ImageGallery(g, {});
-    };
-
     for (i=recs.length - 1; i >= 0; i--) {
       g = recs[i];
-      imagesLoaded(g, slingshot);
+      imagesLoaded(g, (function(g) {
+        return function() {
+          new ImageGallery(g, {});
+        };
+      }(g)));
     }
   }
 


### PR DESCRIPTION
Issue #344

Use a closure inside an IIFE to isolate the `g` variable that holds the
galleries’ root DOM elements.