### PR TITLE
Fix nested divs in aside layout

### DIFF
--- a/assets/targets/components/base/_layout.scss
+++ b/assets/targets/components/base/_layout.scss
@@ -383,6 +383,10 @@ body {
       display: table;
       margin: 0 auto;
       width: 100%;
+      
+      div {
+        display: block;
+      }
     }
 
     aside {


### PR DESCRIPTION
Cancel out the `display: table` declaration for nested divs.

Chaz confirmed this solves the issues he reported.