### PR TITLE
Override display styles for course page side tabs

### DIFF
--- a/assets/targets/components/tabs/_tabs.scss
+++ b/assets/targets/components/tabs/_tabs.scss
@@ -352,7 +352,9 @@
       }
     }
   }
+}
 
+.uomcontent [role="main"] {
   .tabbed-course {
     @extend .tabbed-nav;
     @extend .thin;
@@ -367,6 +369,14 @@
 
     aside h2.subtitle {
       @include rem(padding-bottom, 5px);
+    }
+
+    .degree-plan {
+      display: none;
+
+      &.current {
+        display: block;
+      }
     }
   }
 }


### PR DESCRIPTION
As it turns out, the inner tab `div div` was used to control visibility of side tabs on a very specific inner page of bespoke (degree structure). Fixing it here to keep the styles canonical.