### PR TITLE
Override mobile wrap overflow

### DIFF
--- a/assets/targets/components/tabs/_tabs.scss
+++ b/assets/targets/components/tabs/_tabs.scss
@@ -378,6 +378,10 @@
         display: block;
       }
     }
+
+    .mobile-wrap {
+      overflow: visible;
+    }
   }
 }
 


### PR DESCRIPTION
To hide visible scrollbars in already styled degree structure layout

Fixes #384 