### PR TITLE
Turn FancySelects into navigation menus

### DIFF
--- a/assets/targets/components/forms/_forms-select.scss
+++ b/assets/targets/components/forms/_forms-select.scss
@@ -180,3 +180,35 @@
 .uomcontent fieldset .styled-select {
   @include rem(margin-top, 5px);
 }
+
+.ie8, .ie9 {
+  .uomcontent .styled-select {
+    &,
+    select,
+    select option {
+      background-image: none !important;
+    }
+    
+    select {
+      &,
+      option {
+        background-color: $highlight !important;
+        color: #fff !important;
+      }
+      
+      &.alt,
+      &.alt option {
+        background-color: $white !important;
+        color: $highlight !important;
+      }
+
+      &.clear,
+      &.clear-dark,
+      &.clear option,
+      &.clear-dark option {
+        background-color: #fff !important;
+        color: #000 !important;
+      }
+    }
+  }
+}

--- a/assets/targets/components/forms/fancyselect.js
+++ b/assets/targets/components/forms/fancyselect.js
@@ -20,9 +20,13 @@ function FancySelect(el, props) {
   if (!this.props.parent.hasClass('styled-select')) {
     this.buildWrapper();
   }
+  
+  if (this.el.hasClass('select--nav')) {
+    this.makeNav();
+  }
 }
 
-FancySelect.prototype.buildWrapper = function() {
+FancySelect.prototype.buildWrapper = function () {
   var wrapper = document.createElement('div');
   wrapper.addClass('styled-select');
 
@@ -36,8 +40,28 @@ FancySelect.prototype.buildWrapper = function() {
     wrapper.addClass('clear-dark');
 
   this.props.parent.removeChild(this.el);
-  wrapper.insertBefore(this.el, wrapper.firstChild);
+  wrapper.appendChild(this.el);
   this.props.parent.appendChild(wrapper);
+};
+
+FancySelect.prototype.makeNav = function () {
+  var options = this.el.querySelectorAll('option');
+  
+  // Listen for changes
+  this.el.addEventListener('change', function (e) {
+    var option = options[this.selectedIndex];
+    var val = option ? option.getAttribute('value') : null;
+    
+    // Don't change the location if the `value` attribute is not provided, empty or equal to '#'
+    if (val && val !== '#') {
+      window.location = val;
+    }
+  });
+  
+  // If user comes back to the page with the back button, the previously selected option remains selected.
+  // If they want to then re-select the same option to re-visit the same page, the change listener is not triggered.
+  // Work around this issue by always resetting to the first, placeholder option.
+  this.el.selectedIndex = 0;
 };
 
 module.exports = FancySelect;

--- a/assets/targets/components/index.js
+++ b/assets/targets/components/index.js
@@ -41,14 +41,11 @@ window.UOMloadComponents = function() {
       new Modal(recs[i], {});
   }
 
-  // IE10+
-  if (MSIE_version > 9) {
-    recs = document.querySelectorAll('select');
-    if (recs.length > 0) {
-      FancySelect = require("./forms/fancyselect");
-      for (i=recs.length - 1; i >= 0; i--)
-        new FancySelect(recs[i], {});
-    }
+  recs = document.querySelectorAll('select');
+  if (recs.length > 0) {
+    FancySelect = require("./forms/fancyselect");
+    for (i=recs.length - 1; i >= 0; i--)
+      new FancySelect(recs[i], {});
   }
 
   recs = document.querySelectorAll('[data-tabbed]');

--- a/assets/targets/debranded/index.js
+++ b/assets/targets/debranded/index.js
@@ -47,14 +47,11 @@ window.DSComponentsLoad = function() {
       new Modal(recs[i], {});
   }
 
-  // IE10+
-  if (MSIE_version > 9) {
-    recs = document.querySelectorAll('select');
-    if (recs.length > 0) {
-      FancySelect = require("../components/forms/fancyselect");
-      for (i=recs.length - 1; i >= 0; i--)
-        new FancySelect(recs[i], {});
-    }
+  recs = document.querySelectorAll('select');
+  if (recs.length > 0) {
+    FancySelect = require("../components/forms/fancyselect");
+    for (i=recs.length - 1; i >= 0; i--)
+      new FancySelect(recs[i], {});
   }
 
   recs = document.querySelectorAll('[data-tabbed]');

--- a/assets/targets/forms/index.js
+++ b/assets/targets/forms/index.js
@@ -35,14 +35,11 @@ window.UOMFormLoadComponents = function() {
       new InpageNavigation(recs[i], {});
   }
 
-  // IE10+
-  if (MSIE_version > 9) {
-    recs = document.querySelectorAll('select');
-    if (recs.length > 0) {
-      FancySelect = require("../components/forms/fancyselect");
-      for (i=recs.length - 1; i >= 0; i--)
-        new FancySelect(recs[i], {});
-    }
+  recs = document.querySelectorAll('select');
+  if (recs.length > 0) {
+    FancySelect = require("../components/forms/fancyselect");
+    for (i=recs.length - 1; i >= 0; i--)
+      new FancySelect(recs[i], {});
   }
 
   recs = document.querySelectorAll('form[data-validate]');

--- a/doc-site/views/example_layouts/intranet.slim
+++ b/doc-site/views/example_layouts/intranet.slim
@@ -50,44 +50,44 @@ div.with-login role="main"
       section.navigation-block-listing
         ul.wide
           li.with-dropdown
-            a href="/pages/staff-hub/human-resources"
+            a href="#"
               h3 Human Resources
               p Leave, pay, HR advice, equity and fairness, training and development, career management and job search
-            select class="alt"
-              option Select
-              option Software and applications
-              option IT and computer security
-              option Networks and access support
-              option Computers and printers
-              option Telephones and voicemail
-              option Support for using University systems
-              option Email and calendar
+            select class="alt select--nav"
+              option value="" Select
+              option value="/layouts/no-header" Software and applications
+              option value="#" IT and computer security
+              option value="#" Networks and access support
+              option value="#" Computers and printers
+              option value="#" Telephones and voicemail
+              option value="#" Support for using University systems
+              option value="#" Email and calendar
           li.with-dropdown
             a href="#"
               h3 Information Technology
               p Networks, passwords, IT systems, email, collaboration tools, IT services and access to Themis resources
-            select class="alt"
+            select class="alt select--nav"
               option Select
-              option Software and applications
-              option IT and computer security
-              option Networks and access support
-              option Computers and printers
-              option Telephones and voicemail
-              option Support for using University systems
-              option Email and calendar
+              option value="#" Software and applications
+              option value="#" IT and computer security
+              option value="#" Networks and access support
+              option value="#" Computers and printers
+              option value="#" Telephones and voicemail
+              option value="#" Support for using University systems
+              option value="#" Email and calendar
           li.with-dropdown
             a href="#"
               h3 Finance, Purchasing & Travel
               p Book and organise travel, manage expenses, purchase supplies and equipment, corporate finance
-            select class="alt"
+            select class="alt select--nav"
               option Select
-              option Software and applications
-              option IT and computer security
-              option Networks and access support
-              option Computers and printers
-              option Telephones and voicemail
-              option Support for using University systems
-              option Email and calendar
+              option value="#" Software and applications
+              option value="#" IT and computer security
+              option value="#" Networks and access support
+              option value="#" Computers and printers
+              option value="#" Telephones and voicemail
+              option value="#" Support for using University systems
+              option value="#" Email and calendar
 
       hr.spacer
       section.navigation-block-listing
@@ -140,5 +140,55 @@ div.with-login role="main"
             input aria-required="true" data-error="Please enter your password." id="f-password" name="f[password]" type="password"
         footer
           input type="submit" value="Login"
-  / == partial "pages/staff-hub/enquiry"
-/ == partial 'pages/staff-hub/localnav'
+          
+  .enquiry
+    .enquiry__cta.accordion__title
+      |Have a question?
+      '
+      a.button-small href="enquiry-form" Enquire now
+    .enquiry__form.accordion__hidden
+      form#enquiry-form data-validate=""
+        .fields
+          .errors.copy style='display: none;'
+          fieldset.enquiry-form__details
+            legend Have a question?
+            div
+              label.enquiry-form__label for="f_given" data-required="true" Given name
+              input#f_given.input-medium type="text" placeholder="Given name" name="first_name" aria-required="true"
+            div
+              label.enquiry-form__label for="f_family" data-required="true" Family name
+              input#f_family.input-medium type="text" placeholder="Family name" name="last_name" aria-required="true"
+            div
+              label.enquiry-form__label for="f_email" data-required="true" Email
+              input#f_email.input-medium type="email" placeholder="your@email.com" name="email_address" aria-required="true"
+            div
+              label.enquiry-form__label for="f_phone" data-required="true" Phone
+              input#f_phone.input-medium type="text" placeholder="04..." name="phone" aria-required="true"
+            div
+              label.enquiry-form__label for="f_message" data-required="true" Message
+              textarea#f_message name="enquiry" placeholder="Your enquiry" aria-required="true"
+            .inline
+              input type="checkbox" name="opt_in_faculty" id="faculty_newsletter" value=""
+              label for="faculty_newsletter"
+                span Subscribe to stay up to date with the latest news, events and information
+
+            div
+              input.enquiry-form__submit-button type='submit' value='Send your question'
+              p
+                small
+                  ' The information on this form is being collected by the University of Melbourne for further communication regarding various courses, programs and events at the University in which you have expressed interest. Information collected will only be used by authorised staff for the purpose for which it was collected and will be protected against unauthorized access and use. You can access any personal information the University holds about you. Contact the
+                  a> href="http://www.unimelb.edu.au/unisec/privacy/contact.html" Privacy Officer
+                  ' to find out more. The
+                  a> href="http://www.unimelb.edu.au/disclaimer/privacy.html" University’s Privacy Policy
+                  ' is available online
+                  |.
+    .enquiry__subline
+      .first
+        |or call
+        '
+        a href="tel:136352" 13 MELB (13 6352)
+      .secondary
+        |International:
+        '
+        a href="tel:0061390355511" +61 3 9035 5511
+


### PR DESCRIPTION
… with class `select--nav`.

FancySelects had to be enabled on IE8/9, which required some targeted styling tweaks. Notably, the selects were misbehaving (http://stackoverflow.com/questions/5551288/ies-select-boxes-closes-themselves-when-hovering), which turned out to be caused by changing the `background-color` on hover. Colours are now set for each select design.