### PR TITLE
Alternate syntax for headerless

### DIFF
--- a/assets/targets/components/headers/_headers.scss
+++ b/assets/targets/components/headers/_headers.scss
@@ -9,9 +9,15 @@
   & > article:first-child {
     padding-top: 0;
   }
-  
+
   &.headerless {
     border-top: 8px solid $navy;
+  }
+
+  // Alternate syntax to avoid class on parent container
+  .headerless {
+    border-top: 8px solid $navy;
+    padding-top: 0;
   }
 
   header,

--- a/assets/targets/components/inpage-navigation/_jumpnav.scss
+++ b/assets/targets/components/inpage-navigation/_jumpnav.scss
@@ -125,6 +125,7 @@ body.jumpnav-active {
       padding-top: 10px;
 
       > header:first-child,
+      .headerless,
       footer.cta,
       footer.end,
       footer.contrib {

--- a/doc-site/pages/getting-started.slim.md
+++ b/doc-site/pages/getting-started.slim.md
@@ -1,10 +1,9 @@
 ---
 title: Getting started
 ---
-header
-  / uncomment below to demonstrate header image
-  / style="background:url(/assets/components/headers/assets/repeating-dk.png) center repeat;"
+.headerless
 
+section
   h1 Design System Usage Instructions
 
   .jumpnav

--- a/doc-site/views/components_index.slim
+++ b/doc-site/views/components_index.slim
@@ -1,7 +1,7 @@
 == slim :breadcrumb
 
 div role="main"
-  header.solid-blue
+  header
     h1 Components
 
   section.navigation-text-listing


### PR DESCRIPTION
Adds separate semantic element for headerless border-top - this was initially a convenience for CMS (role="main" is in the layout and can't easily have classes added and removed).

Also noticed that the current implementation (on role="main") doesn't work well with the in page navigation anyway, so this solution might be a little more robust. The previous implementation is still here as well.
