### PR TITLE
Fix OpenStreetMap attribution link

### DIFF
--- a/assets/targets/components/maps/lmaps.js
+++ b/assets/targets/components/maps/lmaps.js
@@ -15,7 +15,7 @@ function LMaps(el, props) {
   this.props.map.setView(this.props.latlng, this.props.zoom);
 
   L.tileLayer('https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}.png?access_token={accessToken}', {
-      attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery © <a href="http://mapbox.com">Mapbox</a>',
+      attribution: 'Map data &copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery © <a href="http://mapbox.com">Mapbox</a>',
       maxZoom: 18,
       id: 'unimelb.cifxgw7yf40guudlyrvtisese',
       accessToken: 'pk.eyJ1IjoidW5pbWVsYiIsImEiOiJjaWZ4Z3c5ZXo0M2R3dTdseGx0NXFyMmdiIn0.RIIkc7B1AboZclV3-JM5bA'


### PR DESCRIPTION
Point to OpenStreetMap’s copyright page rather than homepage. Fixes #387.