### PR TITLE
Fix white space issues in accordion and tabs

### DIFF
--- a/assets/shared/shims.js
+++ b/assets/shared/shims.js
@@ -175,17 +175,19 @@
     };
   }
   
-  // Find the first element child of a node (`Node.firstElementChild` not supported on IE8)
-  window.findFirstElementChild = function (node) {
-    if ('firstElementChild' in node) {
-      return node.firstElementChild;
-    }
-    
-    var child = node.firstChild;
-    while (child && child.nodeType !== 1) {
-      child = child.nextSibling;
-    }
-    return child;
-  };
+  // Find the first element child of an element (`Node.firstElementChild()` is not supported on IE8)
+  if (!Element.prototype.findFirstElementChild) {
+    Element.prototype.findFirstElementChild = function () {
+      if ('firstElementChild' in this) {
+        return this.firstElementChild;
+      }
+
+      var child = this.firstChild;
+      while (child && child.nodeType !== 1) {
+        child = child.nextSibling;
+      }
+      return child;
+    };
+  }
   
 })(this);

--- a/assets/shared/shims.js
+++ b/assets/shared/shims.js
@@ -174,4 +174,18 @@
       return fBound;
     };
   }
+  
+  // Find the first element child of a node (`Node.firstElementChild` not supported on IE8)
+  window.findFirstElementChild = function (node) {
+    if ('firstElementChild' in node) {
+      return node.firstElementChild;
+    }
+    
+    var child = node.firstChild;
+    while (child && child.nodeType !== 1) {
+      child = child.nextSibling;
+    }
+    return child;
+  };
+  
 })(this);

--- a/assets/targets/components/accordion/index.js
+++ b/assets/targets/components/accordion/index.js
@@ -56,7 +56,10 @@ Accordion.prototype.setupCloseButton = function() {
 
     if (this.props.hidden.countSelector('.accordion__close') === 0) {
       if (this.props.hidden.nodeName == 'TR') {
-          this.props.hidden.firstChild.appendChild(close);
+          var firstElem = window.findFirstElementChild(this.props.hidden);
+          if (firstElem) {
+            firstElem.appendChild(close);
+          }
       } else {
         this.props.hidden.appendChild(close);
       }

--- a/assets/targets/components/accordion/index.js
+++ b/assets/targets/components/accordion/index.js
@@ -56,7 +56,7 @@ Accordion.prototype.setupCloseButton = function() {
 
     if (this.props.hidden.countSelector('.accordion__close') === 0) {
       if (this.props.hidden.nodeName == 'TR') {
-          var firstElem = window.findFirstElementChild(this.props.hidden);
+          var firstElem = this.props.hidden.findFirstElementChild();
           if (firstElem) {
             firstElem.appendChild(close);
           }

--- a/assets/targets/components/tabs/index.js
+++ b/assets/targets/components/tabs/index.js
@@ -154,7 +154,7 @@ Tabs.prototype.buildMobileNav = function() {
   selector.setAttribute('role', 'tablist');
 
   for (i=0, max=this.props.tabs.length; i < max; i++) {
-    firstElem = window.findFirstElementChild(this.props.tabs[i]);
+    firstElem = this.props.tabs[i].findFirstElementChild();
     
     // If a child element exist, it's an icon and the label to retrieve is one level deeper
     label = firstElem ? firstElem.firstChild.nodeValue : this.props.tabs[i].firstChild.nodeValue;

--- a/assets/targets/components/tabs/index.js
+++ b/assets/targets/components/tabs/index.js
@@ -146,7 +146,7 @@ Tabs.prototype.activateContainer = function() {
 };
 
 Tabs.prototype.buildMobileNav = function() {
-  var selector, i, max, FancySelect, opt, label;
+  var selector, i, max, firstElem, FancySelect, opt, label;
   this.props.mobilenav = document.createElement('div');
   this.props.mobilenav.addClass('mobile-nav');
 
@@ -154,9 +154,10 @@ Tabs.prototype.buildMobileNav = function() {
   selector.setAttribute('role', 'tablist');
 
   for (i=0, max=this.props.tabs.length; i < max; i++) {
-    label = this.props.tabs[i].firstChild.nodeValue;
-    if (label === null)
-      label = this.props.tabs[i].firstChild.firstChild.nodeValue;
+    firstElem = window.findFirstElementChild(this.props.tabs[i]);
+    
+    // If a child element exist, it's an icon and the label to retrieve is one level deeper
+    label = firstElem ? firstElem.firstChild.nodeValue : this.props.tabs[i].firstChild.nodeValue;
 
     opt = document.createElement('option');
     opt.setAttribute('role', 'tab');


### PR DESCRIPTION
Add a new helper to find the first element child of a node.

The tabs fix assumes that the only possible child element of a tab is an icon - it assumes that no-one uses spans, strong, etc. for other purposes. 