### PR TITLE
Fix lead text padding

### DIFF
--- a/assets/targets/components/tabs/_tabs.scss
+++ b/assets/targets/components/tabs/_tabs.scss
@@ -202,10 +202,6 @@
         max-width: $w-mid;
         position: static;
 
-        & + section {
-          padding-top: 0;
-        }
-
         p {
           color: $black;
         }

--- a/assets/targets/components/text/_lead.scss
+++ b/assets/targets/components/text/_lead.scss
@@ -1,4 +1,4 @@
-.uomcontent {
+.uomcontent [role="main"] {
   .lead {
     @include adjust-font-size-to(19px);
     @include padding-leader(3);
@@ -8,7 +8,9 @@
     color: $black;
     filter: none;
     font-weight: $light;
-    margin: 0 3%;
+    margin: 0 auto;
+    padding-left: 3%;
+    padding-right: 3%;
     position: static;
     text-align: center;
 
@@ -43,14 +45,12 @@
       @include adjust-font-size-to(22px);
     }
 
-    @include breakpoint(wide) {
-      margin: 0 auto;
-    }
-
     &.left {
+      @include padding-leader(2);
+      @include padding-trailer(2);
       @include rem(max-width, $w-sml);
-      @include rem(padding, 48px 0);
-      margin: 0 auto;
+      padding-left: 0;
+      padding-right: 0;
       text-align: left;
 
       p {
@@ -70,17 +70,29 @@
     padding-bottom: 0;
   }
 
-  .lead {
-    margin: 0 auto;
-    padding: 0;
-
-    @include breakpoint(wide) {
+  @include breakpoint(wide) {
+    .lead {
       @include rem(max-width, $w-sml);
+      padding-left: 0;
+      padding-right: 0;
       text-align: left;
     }
   }
-}
 
-.ie8 .uomcontent .lead {
-  margin: 0 auto;
+  // Compensate for padding-bottom of jump-nav on mobile
+  .jump-navigation + .lead {
+    @include padding-leader(2);
+
+    @include breakpoint(wide) {
+      @include padding-leader(3);
+    }
+    
+    &.left {
+      @include padding-leader(1);
+
+      @include breakpoint(wide) {
+        @include padding-leader(2);
+      }
+    }
+  }
 }

--- a/assets/targets/components/text/_lead.scss
+++ b/assets/targets/components/text/_lead.scss
@@ -30,6 +30,10 @@
       }
     }
 
+    & + section {
+      @include padding-leader(0);
+    }
+
     h2 {
       @include padding-leader(0);
     }


### PR DESCRIPTION
- fix top/bottom padding [removed in
v3.4.1](https://github.com/marcom-unimelb/unimelb-design-system/commit/7
8cfd5aab572c2a44c3f3b31fa726a6ae9c1837d)
- use padding rather than margin for 3% left/right spacing (thus remove the need to worry about switching to auto left/right margin at various breakpoints)
- add [role="main"] to override section styles
- account for jump-nav bottom padding on mobile to get the same spacing
above and below the lead text
- generalise removal of top padding on sections that follow leads