### PR TITLE
Social links to share events

### DIFF
--- a/assets/targets/components/events/04-single-date-event-page-with-presenters.slim
+++ b/assets/targets/components/events/04-single-date-event-page-with-presenters.slim
@@ -22,9 +22,10 @@
           | Map
           span.small data-icon="location"
       div
-        a.button-small href=""
-          | Share
-          span.small data-icon="share"
+        ul.social-links
+          li: a href="#": span.small.icon--hide-label data-icon="twitter" Share on Twitter
+          li: a href="#": span.small.icon--hide-label data-icon="facebook" Share on Facebook
+          li: a href="#": span.small.icon--hide-label data-icon="linkedin" Share on LinkedIn
       div
         p
           | T: +61 3 9035 9400

--- a/assets/targets/components/events/_events-detail.scss
+++ b/assets/targets/components/events/_events-detail.scss
@@ -105,6 +105,22 @@
     p {
       padding: 0;
     }
+    
+    .social-links {
+      list-style: none;
+      padding: 0;
+      
+      & > li {
+        display: inline-block;
+        list-style: none;
+        padding: 0;
+        width: auto;
+        
+        &:first-child {
+          margin-left: 0;
+        }
+      }
+    }
   }
 
   .upper {

--- a/assets/targets/components/icons/_svg.scss
+++ b/assets/targets/components/icons/_svg.scss
@@ -48,6 +48,12 @@
       }
     }
 
+    &.icon--hide-label {
+      & > .icon-label {
+        @include screenreaders-only;
+      }
+    }
+
     .icon-label {
       font-weight: $regular;
       margin: 0;


### PR DESCRIPTION
- `social` class already used in injected footer, so use `social-links` instead.
- Scoped to Event pages (`.details`) until further notice.
- Also add a class for visually hiding an icon's label: `icon--hide-label`.