### PR TITLE
Fix figure inside news article

### DIFF
--- a/assets/targets/components/news/04-news-single.slim
+++ b/assets/targets/components/news/04-news-single.slim
@@ -12,6 +12,10 @@ article.news
 
     p Professor Brendan Gleeson, Director of the Melbourne Sustainable Society Institute, said Professor Flannery’s appointment was an outstanding addition to the University community.
 
+    figure.full-width
+      img alt="" src="/assets/news/tsinghua_university_article.jpg"
+      figcaption This is a figure with a caption.
+      
     p “Professor Flannery’s scientific and policy work on sustainability is world class. He is an invaluable source of clear ideas on how we can change direction before it’s too late. We are incredibly pleased to have him on board,” he said.
 
     p Professor Flannery was named Australian of the Year in 2007 for his work on population levels and carbon emissions and was also Chairman of the Copenhagen Climate Council, an international climate change awareness group. He was the Chief Commissioner of the Climate Commission before it was dismantled in 2013 and subsequently launched the Climate Council to ensure the continued provision of independent information on the science of climate change to the Australian public.

--- a/assets/targets/components/news/04-news-single.slim
+++ b/assets/targets/components/news/04-news-single.slim
@@ -14,7 +14,7 @@ article.news
 
     figure.full-width
       img alt="" src="/assets/news/tsinghua_university_article.jpg"
-      figcaption This is a figure with a caption.
+      figcaption This is a 700px-wide image with a caption.
       
     p “Professor Flannery’s scientific and policy work on sustainability is world class. He is an invaluable source of clear ideas on how we can change direction before it’s too late. We are incredibly pleased to have him on board,” he said.
 

--- a/assets/targets/components/news/_article.scss
+++ b/assets/targets/components/news/_article.scss
@@ -51,6 +51,10 @@
     .eg-palette {
       width: 100%;
     }
+    
+    figure.full-width {
+      @include rem(max-width, 700px);
+    }
   }
 
   .video {


### PR DESCRIPTION
Fixes #427. Allow the use of figures with class `full-width` inside news articles.