### PR TITLE
Clearfix search and news listings

### DIFF
--- a/assets/targets/components/inpage-navigation/_jumpnav.scss
+++ b/assets/targets/components/inpage-navigation/_jumpnav.scss
@@ -154,6 +154,12 @@ body.jumpnav-active {
       #outer {
         margin-left: -270px;
       }
+
+      .tabbed .news-tabs,
+      .news-index {
+        margin: 0 auto;
+        width: 94%;
+      }
     }
   }
 }

--- a/assets/targets/components/news/_article.scss
+++ b/assets/targets/components/news/_article.scss
@@ -19,6 +19,7 @@
 
   h1 {
     @include padding-leader(0);
+    @include rem(padding-bottom, 15px);
   }
 
   aside {
@@ -36,6 +37,8 @@
   }
 
   .article {
+    @include rem(padding-top, 5px);
+
     h1,
     ol.steps h2,
     h2,
@@ -51,7 +54,7 @@
     .eg-palette {
       width: 100%;
     }
-    
+
     figure.full-width {
       @include rem(max-width, 700px);
     }

--- a/assets/targets/components/news/_list.scss
+++ b/assets/targets/components/news/_list.scss
@@ -56,13 +56,11 @@
       @include padding-leader(14);
     }
   }
-  @include breakpoint(wide) {
-
-  }
 }
 
 .uomcontent .news-index {
   article {
+    @extend %clearfix;
     @include padding-leader(2);
     @include padding-trailer(2);
     @include rem(max-width, $w-mid);
@@ -71,6 +69,21 @@
 
     &:first-child {
       padding-top: 0;
+    }
+
+    img {
+      @include rem(margin-bottom, 4px);
+      @include rem(margin-top, 4px);
+      display: block;
+      margin-left: auto;
+      margin-right: auto;
+      width: 94%;
+
+      &:first-child {
+        @include rem(margin-left, 10px);
+        @include rem(max-width, 125px);
+        float: right;
+      }
     }
   }
 
@@ -95,49 +108,37 @@
     }
   }
 
-  article img {
-    @include padding-trailer(1);
-    display: block;
-    margin: 0 auto;
-    width: 94%;
-    &:first-child {
-      @include rem(margin-bottom, 0px);
-      @include rem(margin-left, 10px);
-      @include rem(max-width, 125px);
-      display: block;
-      float: right;
-      margin-right: 2%;
-    }
-  }
-
   @include breakpoint(desktop) {
     article {
       @include rem(padding-left, 20px);
       @include rem(padding-right, 20px);
+
+      img {
+        width: 100%;
+
+        &:first-child {
+          @include rem(margin-bottom, -16px);
+          @include rem(margin-top, -16px);
+          @include rem(max-width, 230px);
+          float: left;
+          margin-left: 0;
+          margin-right: 2%;
+
+          & + p,
+          & + p + h1,
+          & + p + h1 + p {
+            @include rem(margin-left, 270px);
+            margin-right: 0;
+            width: auto;
+          }
+        }
+      }
     }
 
     h1 {
       @include adjust-font-size-to(26px);
     }
 
-    article img {
-      width: 100%;
-
-      &:first-child {
-        @include rem(max-width, 230px);
-        display: block;
-        float: left;
-        margin-left: 0;
-
-        & + p,
-        & + p + h1,
-        & + p + h1 + p {
-          @include rem(margin-left, 270px);
-          margin-right: 0;
-          width: auto;
-        }
-      }
-    }
     @include breakpoint(925px) {
       article {
         padding-left: 0;

--- a/assets/targets/components/news/_list.scss
+++ b/assets/targets/components/news/_list.scss
@@ -72,11 +72,10 @@
     }
 
     img {
-      @include rem(margin-bottom, 4px);
-      @include rem(margin-top, 4px);
+      @include rem(margin-bottom, 15px);
       display: block;
       margin-left: auto;
-      margin-right: auto;
+      margin-right: 3%;
       width: 94%;
 
       &:first-child {
@@ -96,6 +95,7 @@
   h1 {
     @include adjust-font-size-to(22px);
     @include rem(max-width, $w-mid);
+    @include rem(padding-bottom, 15px);
   }
 
   p {
@@ -117,8 +117,6 @@
         width: 100%;
 
         &:first-child {
-          @include rem(margin-bottom, -16px);
-          @include rem(margin-top, -16px);
           @include rem(max-width, 230px);
           float: left;
           margin-left: 0;

--- a/assets/targets/components/search/02-search-results.slim
+++ b/assets/targets/components/search/02-search-results.slim
@@ -20,6 +20,7 @@ ol.search-results
   li
     a href="#"
       h3 School of Social and Political Sciences | Political Science
+      figure: img src="/assets/news/tsinghua_university.jpg" alt="Tsinghua University"
       p Political science explores the main issues, ideas, institutions and actors that dominate local, national and international politics. It focuses on how people engage ...
       p.url ssps.unimelb.edu.au/study-areas/political-science
   li
@@ -30,10 +31,8 @@ ol.search-results
   li.maps
     a href="#"
       h3
-        svg role="img" class="icon"
-          use xlink:href="#icon-maps"
-        '
-        |Parkville Campus : Maps
+        span.small> data-icon="map"
+        | Parkville Campus : Maps
       figure
         img src="http://open.mapquestapi.com/staticmap/v4/getmap?size=300,200&zoom=17&center=-37.79894,144.96073&scalebar=false&pois=blue,-37.79894,144.96073&key=Fmjtd%7Cluur2l6r2u%2C7a%3Do5-90ywlw" alt="Map of campus"
       p Maps. Maps Parkville. Parkville Campus. ... Gates. Burnley; Creswick; Dookie;<br> Shepparton; Southbank; Werribee. Maps. More maps and information. ...

--- a/assets/targets/components/search/_search-results.scss
+++ b/assets/targets/components/search/_search-results.scss
@@ -17,11 +17,8 @@
     padding-left: 0;
     padding-right: 0;
 
-    &.promoted {
-
-    }
-
     li {
+      @extend %clearfix;
       @include padding-trailer(1);
       @include trailer(1);
       border-bottom: 1px solid rgba(#000000, 0.1);
@@ -65,6 +62,10 @@
       font-weight: $regular;
       width: 100%;
 
+      .small {
+        vertical-align: bottom;
+      }
+
       svg {
         @include rem(height, 30px);
         @include rem(margin-left, -5px);
@@ -76,10 +77,14 @@
     }
 
     figure {
-      @include rem(margin, 5px 10px 10px 0);
+      @include rem(margin, 5px 16px 0 0);
       @include rem(max-width, 110px);
       float: left;
       padding: 0;
+
+      img {
+        display: block;
+      }
 
       @include breakpoint(desktop) {
         @include rem(max-width, 180px);
@@ -90,7 +95,7 @@
       @include adjust-font-size-to(15px);
       @include padding-trailer(0);
       color: $black;
-      width: 100%;
+      width: auto;
 
       @include breakpoint(desktop) {
         @include adjust-font-size-to(16px);
@@ -99,13 +104,6 @@
       &.url {
         @include adjust-font-size-to(12px);
         color: $highlight;
-      }
-    }
-
-    @include breakpoint(desktop) {
-      h3,
-      p {
-        width: 100%;
       }
     }
   }

--- a/assets/targets/components/search/_search-results.scss
+++ b/assets/targets/components/search/_search-results.scss
@@ -77,7 +77,7 @@
     }
 
     figure {
-      @include rem(margin, 5px 16px 0 0);
+      @include rem(margin, 4px 16px 0 0);
       @include rem(max-width, 110px);
       float: left;
       padding: 0;

--- a/assets/targets/components/text/_figures_floating.scss
+++ b/assets/targets/components/text/_figures_floating.scss
@@ -1,5 +1,5 @@
 .uomcontent {
-	.inset-left {
+  .inset-left {
     @include rem(margin-top, 6px);
     float: none;
     margin-bottom: 0;


### PR DESCRIPTION
Also, fix the map icon in the search results template.

In the news listing, I've set to top and bottom margin of the floated image to `-1rem`. Thought the listing had too much space inside it otherwise. Not sure if what I did is better, though... Feel free to revert the margin to 0.