### PR TITLE
Duplicate missing styled heading from text-listing to block-listing

### DIFF
--- a/assets/targets/components/listings/10-navigational-block-listing-with-linked-header.slim
+++ b/assets/targets/components/listings/10-navigational-block-listing-with-linked-header.slim
@@ -1,4 +1,5 @@
 section.navigation-block-listing
+  h1.aligned-title Title
   ul
     li
       h3

--- a/assets/targets/components/listings/_nav_block.scss
+++ b/assets/targets/components/listings/_nav_block.scss
@@ -6,13 +6,20 @@
   @include rem(padding-right, 25px);
   margin: 0 auto;
 
-  h1.title {
-    @extend %listing-title;
-    max-width: 100%;
+    // &.title {
+    //   @extend %listing-title;
+    //   max-width: 100%;
 
-    @include breakpoint(tablet) {
-      @include rem(padding-left, 20px);
-    }
+    //   @include breakpoint(tablet) {
+    //     @include rem(padding-left, 20px);
+    //   }
+    // }
+
+  h1.aligned-title {
+    @extend %listing-title;
+    @include rem(padding-bottom, 48px);
+    margin-left: 0;
+    max-width: 100%;
   }
 
   ul,
@@ -76,7 +83,7 @@
     @include breakpoint(tablet) {
       h3,
       p {
-        margin: 0 auto;
+        margin: 0 auto 0 0;
         width: 88%;
       }
 
@@ -87,18 +94,13 @@
 
         li {
           display: block;
-          margin: 0 auto;
+          margin: 0 auto 0 0;
           width: 88%;
         }
       }
     }
 
     @include breakpoint(desktop) {
-      h3,
-      p {
-        margin: 0 auto;
-      }
-
       li {
         width: 32.33%;
 


### PR DESCRIPTION
Might need to back-date this to v3.5 and redeploy on the same code (it's only a few small css changes)