### PR TITLE
One-time survey feature

### DIFF
--- a/assets/targets/components/inpage-navigation/jumpnav.js
+++ b/assets/targets/components/inpage-navigation/jumpnav.js
@@ -157,6 +157,10 @@ JumpNav.prototype.initCalcs = function() {
     if (this.props.root.hasClass('floating'))
       this.props.fixPoint = this.props.fixPoint + 35;
 
+    // Increase offset if announcement present
+    if (document.body.hasClass('with-announcement'))
+      this.props.fixPoint += 117;
+
     // Does the page include an inner footer
     var innerFooterHeight = document.querySelector('[role="main"] > footer:last-of-type');
     if (innerFooterHeight) {
@@ -174,6 +178,10 @@ JumpNav.prototype.initCalcs = function() {
 
     // Not really sure what this 60 represents, but it makes it Good
     this.props.stickyEnd = this.props.root.offsetTop + this.props.root.offsetHeight - this.el.offsetHeight - innerFooterHeight - 60;
+
+    // Increase offset if announcement present
+    if (document.body.hasClass('with-announcement'))
+      this.props.stickyEnd += 117;
 
     // 10px margin-top
     this.props.footerOffset = (innerFooterHeight + outerFooterHeight + 10) + 'px';

--- a/assets/targets/injection/announcement/index.scss
+++ b/assets/targets/injection/announcement/index.scss
@@ -3,13 +3,13 @@
   .page-inner .page-announcement {
     display: none;
   }
-  
+
   .page-announcement {
     color: $white;
     position: relative;
     opacity: 1;
     transition: max-height .2s ease;
-    
+
     &--dismissed {
       max-height: 0 !important; // Override inline style
     }
@@ -26,7 +26,7 @@
         background-color: $brand;
         color: $white;
       }
-      
+
       h2 {
         @include adjust-font-size-to(13px);
         @include rem(line-height, 24px);
@@ -50,16 +50,16 @@
           content: '\2192';
           line-height: 0;
         }
-        
+
         strong {
           @include rem(margin-right, 10px);
         }
       }
-      
+
       @include breakpoint(tablet) {
         @include rem(padding, 20px 90px);
         text-align: center;
-        
+
         h2,
         p {
           margin: 0 auto;
@@ -90,18 +90,18 @@
       & > [data-icon="close"] {
         @include rem(height, 24px);
         @include rem(width, 24px);
-        
+
         .icon-label {
           @include screenreaders-only;
         }
       }
-      
+
       @include breakpoint(tablet) {
         @include rem(right, 30px);
       }
     }
   }
-  
+
 }
 
 .ie8 {

--- a/assets/targets/injection/announcement/survey.js
+++ b/assets/targets/injection/announcement/survey.js
@@ -1,6 +1,6 @@
 (function(root) {
 
-  if (document.cookie.replace(/(?:(?:^|.*;\s*)UOMsurveyTaken\s*\=\s*([^;]*).*$)|^.*$/, "$1") !== "tru") {
+  if (document.cookie.replace(/(?:(?:^|.*;\s*)UOMsurveyTaken\s*\=\s*([^;]*).*$)|^.*$/, "$1") !== "true") {
 
     var body = document.body,
         content = document.createElement('div');

--- a/assets/targets/injection/announcement/survey.js
+++ b/assets/targets/injection/announcement/survey.js
@@ -1,0 +1,37 @@
+(function(root) {
+
+  if (document.cookie.replace(/(?:(?:^|.*;\s*)UOMsurveyTaken\s*\=\s*([^;]*).*$)|^.*$/, "$1") !== "tru") {
+
+    var body = document.body,
+        content = document.createElement('div');
+
+    content.setAttribute('class', 'page-announcement');
+    content.id = 'UOMannounce';
+    content.innerHTML = '<a class="page-announcement__message" target="_blank" href="https://www.surveymonkey.com/r/JP3VPSV"><h2>Do you have a minute?</h2><p>Help us improve our website by completing a short survey.</p></a><button id="UOMannounceClose" class="page-announcement__close" type="button">&times;</button>';
+
+    body.insertBefore(content, body.firstChild);
+    body.addClass('with-announcement');
+
+    var el = document.getElementById('UOMannounce');
+
+    // Hide on dismiss
+    document.getElementById('UOMannounceClose').addEventListener('click', function(e) {
+      e.preventDefault();
+      this.parentNode.style.display = 'none';
+      document.body.removeClass('with-announcement');
+
+      // Dismiss forever, practically
+      document.cookie = "UOMsurveyTaken=true; expires=Fri, 31 Dec 9999 23:59:59 GMT";
+    });
+
+    // Hide on link click
+    el.addEventListener('click', function(e) {
+      this.style.display = 'none';
+      document.body.removeClass('with-announcement');
+
+      // Dismiss forever, practically
+      document.cookie = "UOMsurveyTaken=true; expires=Fri, 31 Dec 9999 23:59:59 GMT";
+    });
+  }
+
+})(this);

--- a/assets/targets/injection/announcement/survey.js
+++ b/assets/targets/injection/announcement/survey.js
@@ -1,7 +1,6 @@
 (function(root) {
 
-  if (document.cookie.replace(/(?:(?:^|.*;\s*)UOMsurveyTaken\s*\=\s*([^;]*).*$)|^.*$/, "$1") !== "true") {
-
+  if (document.cookie.replace(/(?:(?:^|.*;\s*)UOMsurveyTaken\s*\=\s*([^;]*).*$)|^.*$/, "$1") !== "true" && document.countSelector('.page-announcement') === 0) {
     var body = document.body,
         content = document.createElement('div');
 

--- a/assets/targets/injection/announcement/survey.scss
+++ b/assets/targets/injection/announcement/survey.scss
@@ -1,70 +1,96 @@
+$legacyblue: #24507e;
+$magicoffset: 117px;
+
 #UOMannounce {
-  color: #fff;
+  color: $white;
   opacity: 1;
-  position: absolute;
-  top: 0;
-  -webkit-transition: max-height 0.2s ease;
-  transition: max-height 0.2s ease;
+  padding-bottom: 0;
+  position: relative;
+  transition: max-height .2s ease;
   width: 100%;
   z-index: 100;
 
-  .page-announcement__message:hover {
-    background-color: #24507e;
-    color: #fff;
-  }
-
-  .page-announcement__close:hover {
-    background-color: #fff;
-    color: #0076de;
+  @include breakpoint(desktop) {
+    @include rem(margin-top, -$magicoffset);
+    padding-bottom: 0;
+    position: absolute;
+    top: 0;
   }
 
   .page-announcement__message {
-    background-color: rgba(#0076de, .95);
-    color: #fff;
+    @include rem(padding, 30px 50px 30px 15px);
+    background-color: $lighterblue;
+    color: $white;
     display: block;
-    padding: 30px 50px 30px 15px;
     text-align: center;
     text-decoration: none;
     width: 100%;
-  }
 
-  .page-announcement__message h2 {
-    color: #e1eaf5;
-    font-size: 12px;
-    font-weight: normal;
-    letter-spacing: normal;
-    line-height: 24px;
-    margin: 0 auto;
-    padding-bottom: 3px;
-    padding-top: 0;
-    text-transform: uppercase;
-  }
+    &:hover {
+      background-color: $legacyblue;
+      color: $white;
+    }
 
-  .page-announcement__message p {
+    h2 {
+      @include rem(font-size, 12px);
+      @include rem(line-height, 24px);
+      @include rem(padding-bottom, 3px);
+      color: $lightestblue;
+      font-weight: $regular;
+      letter-spacing: normal;
+      margin: 0 auto;
+      padding-top: 0;
+      text-transform: uppercase;
+    }
 
-    color: #fff;
-    font-size: 18px;
-    text-decoration: underline;
+    p {
+      @include rem(font-size, 18px);
+      color: $white;
+      text-decoration: underline;
+    }
   }
 
   .page-announcement__close {
+    @include rem(border-radius, 3px);
+    @include rem(font-size, 36px);
+    @include rem(height, 40px);
+    @include rem(line-height, 20px);
+    @include rem(padding, 5px 10px 15px);
+    @include rem(right, 15px);
+    @include rem(top, 35px);
+    @include rem(width, 40px);
     background: none;
-    border: none;
-    border-radius: 3px;
-    color: #fff;
+    border: 0;
+    color: $white;
     cursor: pointer;
-    font-size: 36px;
-    font-weight: 100;
-    height: 40px;
-    line-height: 20px;
     display: block;
+    font-weight: 100;
     margin-top: 0;
-    padding: 5px 10px 15px;
     position: absolute;
-    right: 15px;
-    top: 35px;
-    -webkit-transition: background-color 0.15s, color 0.15s;
-    transition: background-color 0.15s, color 0.15s;
-    width: 40px;
+    transition: background-color .15s, color .15s;
+
+    &:hover {
+      background-color: $white;
+      color: $lighterblue;
+    }
+  }
+}
+
+body.with-announcement {
+  @include breakpoint(desktop) {
+    @include rem(top, $magicoffset);
+    position: relative;
+  }
+}
+
+body.with-announcement.jumpnav-active .uomcontent {
+  [role="main"] {
+    padding-top: 0;
+  }
+
+  #outer.fixed.headless {
+    @include breakpoint(desktop) {
+      @include rem(margin-top, 240px);
+    }
   }
 }

--- a/assets/targets/injection/announcement/survey.scss
+++ b/assets/targets/injection/announcement/survey.scss
@@ -55,7 +55,7 @@ $magicoffset: 117px;
     @include rem(border-radius, 3px);
     @include rem(font-size, 36px);
     @include rem(height, 40px);
-    @include rem(line-height, 20px);
+    @include rem(line-height, 30px);
     @include rem(padding, 5px 10px 15px);
     @include rem(right, 15px);
     @include rem(top, 35px);

--- a/assets/targets/injection/announcement/survey.scss
+++ b/assets/targets/injection/announcement/survey.scss
@@ -1,0 +1,70 @@
+#UOMannounce {
+  color: #fff;
+  opacity: 1;
+  position: absolute;
+  top: 0;
+  -webkit-transition: max-height 0.2s ease;
+  transition: max-height 0.2s ease;
+  width: 100%;
+  z-index: 100;
+
+  .page-announcement__message:hover {
+    background-color: #24507e;
+    color: #fff;
+  }
+
+  .page-announcement__close:hover {
+    background-color: #fff;
+    color: #0076de;
+  }
+
+  .page-announcement__message {
+    background-color: rgba(#0076de, .95);
+    color: #fff;
+    display: block;
+    padding: 30px 50px 30px 15px;
+    text-align: center;
+    text-decoration: none;
+    width: 100%;
+  }
+
+  .page-announcement__message h2 {
+    color: #e1eaf5;
+    font-size: 12px;
+    font-weight: normal;
+    letter-spacing: normal;
+    line-height: 24px;
+    margin: 0 auto;
+    padding-bottom: 3px;
+    padding-top: 0;
+    text-transform: uppercase;
+  }
+
+  .page-announcement__message p {
+
+    color: #fff;
+    font-size: 18px;
+    text-decoration: underline;
+  }
+
+  .page-announcement__close {
+    background: none;
+    border: none;
+    border-radius: 3px;
+    color: #fff;
+    cursor: pointer;
+    font-size: 36px;
+    font-weight: 100;
+    height: 40px;
+    line-height: 20px;
+    display: block;
+    margin-top: 0;
+    padding: 5px 10px 15px;
+    position: absolute;
+    right: 15px;
+    top: 35px;
+    -webkit-transition: background-color 0.15s, color 0.15s;
+    transition: background-color 0.15s, color 0.15s;
+    width: 40px;
+  }
+}

--- a/assets/targets/injection/announcement/survey.scss
+++ b/assets/targets/injection/announcement/survey.scss
@@ -8,13 +8,14 @@ $magicoffset: 117px;
   position: relative;
   transition: max-height .2s ease;
   width: 100%;
-  z-index: 100;
+  z-index: 10;
 
   @include breakpoint(desktop) {
     @include rem(margin-top, -$magicoffset);
     padding-bottom: 0;
     position: absolute;
     top: 0;
+    z-index: 100;
   }
 
   .page-announcement__message {
@@ -76,10 +77,27 @@ $magicoffset: 117px;
   }
 }
 
+// Adjustments to layout
 body.with-announcement {
   @include breakpoint(desktop) {
     @include rem(top, $magicoffset);
     position: relative;
+  }
+
+  .uomcontent {
+    @include breakpoint(desktop) {
+      #sitemap.active,
+      .sitemap-label,
+      #globalsitemap.active {
+        @include rem(top, $magicoffset);
+      }
+
+      .page-header.fixed.active + .page-inner + .modal__blanket + #sitemap.active,
+      .page-header.fixed.active + .page-inner + .modal__blanket + #sitemap.active + .sitemap-label,
+      .page-header.fixed.active + .page-inner + .modal__blanket + #sitemap + .sitemap-label + #globalsitemap.active {
+        top: 0;
+      }
+    }
   }
 }
 
@@ -89,7 +107,7 @@ body.with-announcement.jumpnav-active .uomcontent {
   }
 
   #outer.fixed.headless {
-    @include breakpoint(desktop) {
+    @include breakpoint(wide) {
       @include rem(margin-top, 240px);
     }
   }

--- a/assets/targets/injection/footer/index.scss
+++ b/assets/targets/injection/footer/index.scss
@@ -48,9 +48,13 @@
 
     a {
       @include rem(font-size, 11px);
+      @include rem(line-height, 46px);
       letter-spacing: 1px;
-      line-height: 1.6em;
       text-transform: uppercase;
+
+      @include breakpoint(desktop) {
+        line-height: 1.6em;
+      }
     }
   }
 

--- a/assets/targets/injection/index.js
+++ b/assets/targets/injection/index.js
@@ -33,6 +33,8 @@ window.UOMloadInjection = function() {
 
   Accouncement = require('./announcement/index.es6');
   new Accouncement({});
+
+  require("./announcement/survey");
 };
 
 // Execute when ready

--- a/assets/targets/injection/index.scss
+++ b/assets/targets/injection/index.scss
@@ -44,6 +44,7 @@ body {
 @import 'header/index';
 @import 'footer/index';
 @import 'announcement/index';
+@import 'announcement/survey';
 @import 'nav/index';
 
 .hidden {


### PR DESCRIPTION
Rework announcement to work across all pages, adjusting relative top-0 where necessary (jumpnav, local nav, etc)

_Note: This is a very specific solution and not terribly extensible, will need to revisit and abstract this after the survey period!_

The behaviour is inherited from the solution developed for the old (wbg-templates) injection, event setup and dismissal cookie is consistent so it should work across both.

Will not fire if a page announcement is already added via markup (eg. staff hub).

Also: fix the footer title alignment on mobile.