### PR TITLE
Fix icon with hidden label

### DIFF
--- a/assets/shared/_patterns_accessibility.scss
+++ b/assets/shared/_patterns_accessibility.scss
@@ -8,12 +8,15 @@
 }
 
 // Hide only visually, but have it available for screenreaders
-//   www.webaim.org/techniques/css/invisiblecontent/
-//   Solution from: j.mp/visuallyhidden - Thanks Jonathan Neal!
+// Parent element should have `overflow: hidden;` and `position: relative;` to solve outline bug in Chrome
+// http://snook.ca/archives/html_and_css/hiding-content-for-accessibility
+// http://stackoverflow.com/questions/3970455/overflow-hidden-not-working
 @mixin screenreaders-only {
-  position: absolute !important;
-  clip: rect(1px 1px 1px 1px); /* IE6, IE7 */
   clip: rect(1px, 1px, 1px, 1px);
+  height: 1px;
+  overflow: hidden;
+  position: absolute !important;
+  width: 1px;
 }
 
 // Hide visually and from screenreaders, but maintain layout

--- a/assets/targets/components/forms/10-inline-form.slim
+++ b/assets/targets/components/forms/10-inline-form.slim
@@ -4,6 +4,15 @@ form action="" method="get"
       span.fill
         input aria-required="true" placeholder="Inline form" name="query" type="text" data-error="Please enter a keyword" aria-label="Inline form"
       span
+        button.inline-button type="submit"
+          span.small.icon--hide-label data-icon="send" Go for it!
+
+form action="" method="get"
+  fieldset
+    .inline.attached
+      span.fill
+        input aria-required="true" placeholder="Inline form" name="query" type="text" data-error="Please enter a keyword" aria-label="Inline form"
+      span
         input.inline-button type="submit" value="Go for it!"
 
 form action="" method="get"

--- a/assets/targets/components/icons/_svg.scss
+++ b/assets/targets/components/icons/_svg.scss
@@ -49,6 +49,10 @@
     }
 
     &.icon--hide-label {
+      // Fix outline bug in Chrome
+      overflow: hidden;
+      position: relative;
+      
       & > .icon-label {
         @include screenreaders-only;
       }


### PR DESCRIPTION
When used inside button, the label of an icon with a hidden label
creates a weird outline.