### PR TITLE
On page load, check right away whether header should have class `fixed`

### DIFF
--- a/assets/targets/injection/header/index.es6
+++ b/assets/targets/injection/header/index.es6
@@ -25,6 +25,7 @@ function InjectHeader(props) {
   // Exclude IE8, can't polyfill window scroll event
   if (!/(MSIE 8.0)/g.test(navigator.userAgent)) {
     window.addEventListener("scroll", this.handleScroll.bind(this));
+    this.handleScroll(); // Check once on page load
   }
 }
 


### PR DESCRIPTION
(i.e. don't wait for first scroll)