### PR TITLE
Use CSS column layout for jumpnav on mobile, if supported

### DIFF
--- a/assets/targets/components/inpage-navigation/_jumpnav.scss
+++ b/assets/targets/components/inpage-navigation/_jumpnav.scss
@@ -20,9 +20,9 @@
 
     &:first-child {
       @include rem(padding-bottom, 7px);
+      @include rem(margin-bottom, 7px);
       border-bottom: 1px solid $lightergray;
       letter-spacing: 1px;
-      margin-bottom: 0;
       text-transform: uppercase;
       width: 100%;
 
@@ -68,8 +68,29 @@ body.jumpnav-active {
   .uomcontent #outer {
     @extend %jump;
 
+    @supports (column-span: all) {
+      columns: 2;
+
+      li {
+        width: 100%;
+
+        &:first-child {
+          column-span: all;
+          display: block;
+        }
+      }
+
+      @include breakpoint(wide) {
+        columns: auto;
+      }
+    }
+
     @include breakpoint(desktop) {
       @include rem(padding-top, 80px);
+      
+      li:first-child {
+        margin-bottom: 0;
+      }
 
       a {
         border-bottom: 1px solid $lightergray;


### PR DESCRIPTION
Fixes #502. This will work only in browsers that support both the `@supports` directive and the `column-span` property. At the moment, this includes Edge and Chrome, but excludes Firefox and IE<11.

Also, add a slight margin below the jumpnav heading on mobile.
