### PR TITLE
Accessible drop-down navigation menu

### DIFF
--- a/assets/targets/components/buttons/_buttons.scss
+++ b/assets/targets/components/buttons/_buttons.scss
@@ -307,4 +307,21 @@
       @include rem(font-size, 16px);
     }
   }
+
+  /* Button reset, for buttons used for interactions purposes (e.g. `dropdown-nav`) */
+  .button-reset {
+    background: none;
+    border: none;
+    cursor: pointer;
+    font: inherit;
+    line-height: normal;
+    margin: 0;
+    padding: 0;
+    text-align: left;
+
+    &::-moz-focus-inner {
+      border: 0;
+      padding: 0;
+    }
+  }
 }

--- a/assets/targets/components/index.js
+++ b/assets/targets/components/index.js
@@ -67,7 +67,7 @@ window.UOMbind = function(component) {
 window.UOMloadComponents = function() {
   "use strict";
 
-  var recs, i, g, SidebarTabs, JumpNav, CheckboxHelper, FancySelect,
+  var recs, i, g, SidebarTabs, JumpNav, DropdownNav, CheckboxHelper, FancySelect,
     ImageGallery, imagesLoaded, slingshot, LMaps, style, script;
 
   window.UOMbind('accordion');
@@ -98,6 +98,13 @@ window.UOMloadComponents = function() {
   }
 
   window.UOMbind('inpage-navigation');
+  
+  recs = document.querySelectorAll('.dropdown-nav');
+  if (recs.length > 0) {
+    DropdownNav = require("./inpage-navigation/dropdown-nav");
+    for (i=recs.length - 1; i >= 0; i--)
+      new DropdownNav(recs[i], {});
+  }
 
   recs = document.querySelectorAll('input[type="radio"],input[type="checkbox"]');
   if (recs.length > 0) {

--- a/assets/targets/components/inpage-navigation/01-dropdown-navigation.slim
+++ b/assets/targets/components/inpage-navigation/01-dropdown-navigation.slim
@@ -1,0 +1,7 @@
+section
+  .dropdown-nav role="navigation" aria-haspopup="true" aria-expanded="false"
+    button.dropdown-nav__btn.button-reset type="button" aria-controls="popup1" Navigate to...
+    ul.dropdown-nav__list#popup1 hidden=true
+      li: a.dropdown-nav__link href="forms" Forms
+      li: a.dropdown-nav__link href="headers" Headers
+      li: a.dropdown-nav__link href="icons" Icons

--- a/assets/targets/components/inpage-navigation/_dropdown-nav.scss
+++ b/assets/targets/components/inpage-navigation/_dropdown-nav.scss
@@ -1,0 +1,58 @@
+.uomcontent .dropdown-nav {
+
+  &__btn {
+    @extend %ellipsis;
+    @include rem(font-size, 18px);
+    @include rem(padding, 8px 50px 8px 10px);
+    background: $white no-repeat right 8px center url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzRweCIgaGVpZ2h0PSIzNHB4IiB2aWV3Qm94PSIwIDAgNDkgNDgiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayI+PGcgZmlsbD0iIzAwNzZkZSI+PHBhdGggZD0iTTI0LDQgQzEyLjk1LDQgNCwxMi45NSA0LDI0IEM0LDM1LjA1IDEyLjk1LDQ0IDI0LDQ0IEMzNS4wNSw0NCA0NCwzNS4wNSA0NCwyNCBDNDQsMTIuOTUgMzUuMDUsNCAyNCw0IEwyNCw0IFogTTI0LDI4IEwxNiwyMCBMMzIsMjAgTDI0LDI4IEwyNCwyOCBaIj48L3BhdGg+PC9nPjwvc3ZnPg==');
+    border: 1px solid $highlight;
+    border-radius: 3px;
+    color: $highlight;
+    display: block;
+    line-height: 1.55;
+    width: 100%;
+    
+    &:hover,
+    &:focus {
+      background-color: $lightestblue;
+      text-decoration: underline;
+    }
+  }
+  
+  &__list {
+    background-color: $lightestblue;
+    border: 1px solid $highlight;
+    border-radius: 3px;
+    margin: 0;
+    padding: 0;
+    
+    & > li {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+    }
+  }
+  
+  &__link {
+    @include rem(padding, 8px 25px);
+    display: block;
+    text-decoration: none;
+    
+    &:hover {
+      background-color: $highlight;
+      color: $white;
+      text-decoration: underline;
+    }
+    
+    &:focus {
+      outline: 1px dashed $black;
+    }
+  }
+  
+  &[aria-expanded="true"] {
+    .dropdown-nav__btn {
+      background-color: $lightestblue;
+    }
+  }
+
+}

--- a/assets/targets/components/inpage-navigation/dropdown-nav.js
+++ b/assets/targets/components/inpage-navigation/dropdown-nav.js
@@ -1,0 +1,48 @@
+/**
+ * Drop-down navigation
+ * @param  {Element} el
+ * @param  {Object} props
+ */
+function DropdownNav(el, props) {
+  this.el = el;
+  this.props = props || {};
+  this.props.btn = this.el.querySelector('.dropdown-nav__btn');
+  this.props.list = this.el.querySelector('.dropdown-nav__list');
+  this.props.firstLink = this.props.list.querySelectorAll('.dropdown-nav__link')[0];
+
+  // Event bindings, exclude noscroll and modal and rebind
+  if (!this.el.hasAttribute('data-bound')) {
+    this.props.btn.addEventListener('click', this.toggle.bind(this));
+    this.props.btn.addEventListener('keypress', function (evt) {
+      if (evt.keyCode === 13) {
+        evt.preventDefault(); // Prevent key-press events from triggering clicks
+        this.toggle(evt, true);
+      }
+    }.bind(this));
+    
+    this.el.setAttribute('data-bound', true);
+  }
+}
+
+/**
+ * Expand or collapse the drop-down menu.
+ * @param {Boolean} focus - whether to give focus to the first link after expanding
+ */
+DropdownNav.prototype.toggle = function(evt, focus) {
+  if (this.el.getAttribute('aria-expanded') === 'false') {
+    // Expand
+    this.el.setAttribute('aria-expanded', 'true');
+    this.props.list.removeAttribute('hidden');
+  
+    if (focus) {
+      // Give focus to the first link in the list
+      this.props.firstLink.focus();
+    }
+  } else {
+    // Collapse
+    this.el.setAttribute('aria-expanded', 'false');
+    this.props.list.setAttribute('hidden', 'hidden');
+  }
+};
+
+module.exports = DropdownNav;

--- a/assets/targets/components/inpage-navigation/index.scss
+++ b/assets/targets/components/inpage-navigation/index.scss
@@ -1,2 +1,3 @@
 @import 'jumpnav';
 @import 'indexnav';
+@import 'dropdown-nav';


### PR DESCRIPTION
Fixes #497 - Initial implementation looks similar to fancy selects. This is not ideal, as the behaviour of `<select>` elements is not fully replicated (e.g. click outside to close, arrows to navigate between items, etc.) Should perhaps look more like an accordion.