### PR TITLE
Refactor menu animation

### DIFF
--- a/assets/shared/_globals.scss
+++ b/assets/shared/_globals.scss
@@ -1,8 +1,3 @@
-@mixin translateX($d) {
-  transform: translate3d($d, 0, 0);
-  transition: transform .3s ease;
-}
-
 @mixin appearance($a) {
   -webkit-appearance: $a;
   -moz-appearance: $a;
@@ -110,13 +105,6 @@ $cdnurl: '//d2h9b02ioca40d.cloudfront.net/shared';
   background-position: top center;
   background-repeat: no-repeat;
   background-size: cover;
-}
-
-%smooth-translate {
-  -moz-transition: -moz-transform .3s ease;
-  -ms-transition: -ms-transform .3s ease;
-  -webkit-transition: -webkit-transform .3s ease;
-  transition: transform .3s ease;
 }
 
 %normalise {

--- a/assets/shared/blanket.scss
+++ b/assets/shared/blanket.scss
@@ -5,21 +5,19 @@
 
 .uomcontent {
   .modal__blanket {
-    @include opacity(0);
-    background: #000;
+    background-color: #000;
     display: none;
-    height: 101.5%;
+    height: 100%;
     left: 0;
-    overflow: scroll;
+    opacity: .5;
+    overflow: hidden;
     position: fixed;
     top: 0;
-    width: 101.5%;
-    z-index: 1;
+    width: 100%;
+    z-index: 14;
 
     &.on {
-      @include opacity(.5);
       display: block;
-      z-index: 14;
     }
   }
 }

--- a/assets/shared/blanket.scss
+++ b/assets/shared/blanket.scss
@@ -5,11 +5,11 @@
 
 .uomcontent {
   .modal__blanket {
+    @include opacity(.5);
     background-color: #000;
     display: none;
     height: 100%;
     left: 0;
-    opacity: .5;
     overflow: hidden;
     position: fixed;
     top: 0;

--- a/assets/targets/components/_print.scss
+++ b/assets/targets/components/_print.scss
@@ -30,7 +30,7 @@ $white: #ffffff;
     .page-footer,
     [role="sitemap"],
     [role="navigation"],
-    .sitemap-label {
+    .sitemap-trigger {
       display: none;
     }
 

--- a/assets/targets/injection/index.scss
+++ b/assets/targets/injection/index.scss
@@ -32,6 +32,9 @@ $light: 300;
 
 $ff-sans: Roboto, Helvetica, Arial, sans-serif;
 
+// Transitions
+$smooth-transform: transform .3s ease;
+
 html,
 body {
   height: 100%;

--- a/assets/targets/injection/nav/_globalnav.scss
+++ b/assets/targets/injection/nav/_globalnav.scss
@@ -1,39 +1,38 @@
 .uomcontent [role="navigation"]#globalsitemap {
   @extend %normalise;
-  @extend %smooth-translate;
   @extend %wrapper;
-  @include rem(padding, 0 0 30px);
-  @include translateX(100%);
+  @include rem(padding, 0 3% 30px);
   background-color: $navy;
   font-family: $ff-sans;
   height: 100%;
   margin: 0;
-  max-width: 100%;
+  max-width: none;
   position: fixed;
-  right: 0;
+  right: -100%;
   top: 0;
+  transform: translateX(0);
+  transition: $smooth-transform;
   width: 100%;
-  z-index: 0;
+  z-index: 17;
+
+  &.active {
+    box-shadow: 1px 0 12px 3px rgba($black, .6);
+    overflow: auto;
+    position: fixed;
+    transform: translateX(-100%);
+    –webkit-overflow-scrolling: touch;
+  }
+  
+  @include breakpoint(tablet) {
+    @include rem(padding, 0 130px 30px 40px);
+    
+    &.active {
+      transform: translateX(-100%) translateX(90px);
+    }
+  }
 
   * {
     @extend %normalise;
-  }
-
-  &.active {
-    @include translateX(0);
-    left: 0;
-    overflow: auto;
-    padding-left: 3%;
-    padding-right: 3%;
-    position: fixed;
-    z-index: 17;
-    –webkit-overflow-scrolling: touch;
-
-    @include breakpoint(tablet) {
-      @include rem(left, 90px);
-      @include rem(padding-left, 40px);
-      @include rem(padding-right, 155px);
-    }
   }
 
   a {

--- a/assets/targets/injection/nav/_globalnav.scss
+++ b/assets/targets/injection/nav/_globalnav.scss
@@ -18,7 +18,6 @@
   &.active {
     box-shadow: 1px 0 12px 3px rgba($black, .6);
     overflow: auto;
-    position: fixed;
     transform: translateX(-100%);
     –webkit-overflow-scrolling: touch;
   }
@@ -37,6 +36,7 @@
 
   a {
     @include rem(padding-top, 10px);
+    color: $lightblue;
     color: rgba($white, .6);
     display: block;
     font-weight: $light;
@@ -57,6 +57,7 @@
     @include rem(padding-bottom, 10px);
     @include rem(padding-top, 30px);
     border-bottom: 1px solid $blue;
+    color: $lightblue;
     color: rgba($white, .6);
     line-height: 1.2;
     padding-right: 3%;
@@ -236,7 +237,7 @@
     text-decoration: none;
     text-transform: uppercase;
 
-    &::before {
+    &:before {
       @include rem(font-size, 24px);
       @include rem(margin-right, 8px);
       color: rgba($white, .4);
@@ -252,7 +253,7 @@
       text-decoration: underline;
     }
 
-    &:hover::before {
+    &:hover:before {
       @include animation(chevronback 1s infinite ease-in-out);
       color: $white;
       text-decoration: none;
@@ -306,23 +307,19 @@
 
 body.ie {
   .uomcontent [role="navigation"]#globalsitemap {
-    display: none;
-    z-index: 0;
-
-    &.active {
-      background: $navy;
-      display: block;
-      z-index: 100;
-    }
+//    display: none;
+//    z-index: 0;
+//
+//    &.active {
+//      right: 0;
+//      background: $navy;
+//      display: block;
+//      z-index: 100;
+//    }
 
     .logo * {
       border: 0 none;
       outline: 0;
-    }
-
-    h2,
-    a {
-      color: $lightblue;
     }
 
     form {
@@ -375,6 +372,14 @@ body.ie {
       a {
         padding-left: 0;
       }
+    }
+  }
+}
+
+body.ie8 {
+  .uomcontent [role="navigation"]#globalsitemap {
+    &.active {
+      right: 0;
     }
   }
 }

--- a/assets/targets/injection/nav/_globalnav.scss
+++ b/assets/targets/injection/nav/_globalnav.scss
@@ -238,15 +238,13 @@
 
     &::before {
       @include rem(font-size, 24px);
-      @include rem(height, 10px);
-      @include rem(margin-right, 5px);
+      @include rem(margin-right, 8px);
       color: rgba($white, .4);
       content: '\2039';
-      display: block;
-      float: left;
+      display: inline-block;
       font-weight: $regular;
-      line-height: .8;
-      text-indent: 0;
+      line-height: 1;
+      vertical-align: -1px;
     }
 
     &:hover {
@@ -257,6 +255,7 @@
     &:hover::before {
       @include animation(chevronback 1s infinite ease-in-out);
       color: $white;
+      text-decoration: none;
     }
   }
 

--- a/assets/targets/injection/nav/_localnav.scss
+++ b/assets/targets/injection/nav/_localnav.scss
@@ -35,6 +35,10 @@
     .sitemap-trigger {
       margin-left: -100px;
     }
+
+    &.inner-open {
+      overflow: hidden;
+    }
   }
 
   @include breakpoint(tablet) {

--- a/assets/targets/injection/nav/_localnav.scss
+++ b/assets/targets/injection/nav/_localnav.scss
@@ -111,22 +111,19 @@
   }
 
   .inner {
-    @include translateX(0);
     background-color: $navy;
     height: 100%;
-
     overflow-x: hidden;
     overflow-y: auto;
-
     padding-right: 40px;
     position: absolute;
     top: 0;
+    transform: translateX(100%);
+    transition: transform .3s ease;
     width: 100%;
-    z-index: 10;
 
-    &.hide {
-      @include translateX(100%);
-      z-index: 1;
+    &.active {
+      transform: translateX(0);
     }
 
     li {

--- a/assets/targets/injection/nav/_localnav.scss
+++ b/assets/targets/injection/nav/_localnav.scss
@@ -1,20 +1,14 @@
 @include keyframes(chevronback) {
   0% {
-    @include transform(translateX(0));
+    transform: translateX(0);
   }
   50% {
-    @include transform(translateX(-5px));
-  }
-  100% {
-    @include transform(translateX(0));
+    transform: translateX(-5px);
   }
 }
 
 .uomcontent [role="navigation"]#sitemap {
   @extend %normalise;
-  @extend %smooth-translate;
-  @include transform-origin(0% 0%);
-  @include transform-style(preserve-3d);
   background-color: $menu;
   color: $white;
   font-family: $ff-sans;
@@ -25,18 +19,18 @@
   position: fixed;
   right: -100%;
   top: 0;
+  transform: translateX(0);
+  transition: $smooth-transform;
   width: 100%;
-  z-index: 1;
+  z-index: 15;
 
   * {
     @extend %normalise;
   }
 
   &.active {
-    @include transition(right .3s ease-out);
     box-shadow: 1px 0 12px 3px rgba($black, .6);
-    right: 0;
-    z-index: 15;
+    transform: translateX(-100%);
 
     .sitemap-trigger {
       margin-left: -100px;
@@ -48,17 +42,12 @@
   }
 
   @include breakpoint(tablet) {
-    margin-right: 40px;
-    width: 300px;
-  }
-
-
-  &.global-active {
-    @include translateX(-100%);
-    display: block;
-
-    @include breakpoint(tablet) {
-      transform: translate(-100%, 0) translate(110px, 0);
+    margin-right: $width-sitemap-trigger;
+    right: $offset-localnav;
+    width: $width-localnav;
+    
+    &.active {
+      transform: translateX($offset-localnav);
     }
   }
 
@@ -119,7 +108,7 @@
     position: absolute;
     top: 0;
     transform: translateX(100%);
-    transition: transform .3s ease;
+    transition: $smooth-transform;
     width: 100%;
 
     &.active {

--- a/assets/targets/injection/nav/_localnav.scss
+++ b/assets/targets/injection/nav/_localnav.scss
@@ -15,7 +15,7 @@
   height: 100%;
   overflow-x: hidden;
   overflow-y: auto;
-  padding: 0;
+  padding-right: $width-sitemap-trigger;
   position: fixed;
   right: -100%;
   top: 0;
@@ -34,20 +34,21 @@
 
     .sitemap-trigger {
       margin-left: -100px;
-
-      @include breakpoint(tablet) {
-        margin-left: 0;
-      }
     }
   }
 
   @include breakpoint(tablet) {
     margin-right: $width-sitemap-trigger;
+    padding-right: 0;
     right: $offset-localnav;
     width: $width-localnav;
     
     &.active {
       transform: translateX($offset-localnav);
+      
+      .sitemap-trigger {
+        margin-left: 0;
+      }
     }
   }
 
@@ -61,13 +62,13 @@
   }
 
   .w {
-    @include rem(padding-right, 40px);
+    @include rem(padding-right, $width-sitemap-trigger);
     height: 100%;
     overflow-x: hidden;
     overflow-y: auto;
 
     @include breakpoint(tablet) {
-      @include rem(width, 300px);
+      @include rem(width, $width-localnav);
       padding-right: 0;
     }
   }
@@ -79,6 +80,7 @@
 
     &.meta {
       @include rem(padding, 20px 0);
+      border-top: 1px solid darken($borderblue, 30%);
       border-top: 1px solid rgba($white, .1);
 
       li {
@@ -89,6 +91,7 @@
         @include rem(font-size, 13px);
         @include rem(line-height, 24px);
         @include rem(padding, 2px 20px);
+        color: #8ca2b8;
         color: rgba($white, .7);
 
         &:hover {
@@ -104,15 +107,16 @@
     height: 100%;
     overflow-x: hidden;
     overflow-y: auto;
-    padding-right: 40px;
+    padding-right: $width-sitemap-trigger;
     position: absolute;
+    right: -100%;
     top: 0;
-    transform: translateX(100%);
+    transform: translateX(0);
     transition: $smooth-transform;
     width: 100%;
 
     &.active {
-      transform: translateX(0);
+      transform: translateX(-100%);
     }
 
     li {
@@ -131,6 +135,7 @@
   }
 
   li {
+    border-top: 1px solid darken($borderblue, 30%);
     border-top: 1px solid rgba($white, .1);
     list-style-type: none;
     margin-left: 0;
@@ -143,6 +148,7 @@
     @include rem(letter-spacing, 1px);
     @include rem(padding, 20px);
     background-color: darken($menu, 3%);
+    color: $lightblue;
     color: rgba($white, .6);
     cursor: pointer;
     display: block;
@@ -185,34 +191,33 @@
 
   .back {
     background-color: $menu;
+    color: $lightblue;
     color: rgba($white, .6);
     cursor: pointer;
 
-    &::before {
+    &:before {
       @include rem(font-size, 24px);
       content: '\2039';
       float: left;
       font-weight: $regular;
-      line-height: .9;
+      line-height: .85;
       padding-right: 10px;
     }
 
-    &:hover {
-      &::before {
-        @include animation(chevronback 1s infinite ease-in-out);
-      }
+    &:hover:before {
+      @include animation(chevronback 1s infinite ease-in-out);
     }
   }
 
   .parent {
     cursor: pointer;
 
-    &::after {
+    &:after {
       @include rem(font-size, 24px);
       content: '\203a';
       float: right;
       font-weight: $regular;
-      line-height: .9;
+      line-height: .85;
       z-index: 9;
     }
   }
@@ -228,83 +233,24 @@
   }
 }
 
-body.ie {
+body.ie8 {
   .uomcontent [role="navigation"]#sitemap {
-    display: none;
-
-    .w,
+    padding-right: 0;
+    right: -$width-localnav;
+    width: $width-localnav;
+    
+    &.active,
+    .inner.active {
+      right: 0;
+    }
+    
     .inner {
       padding-right: 0;
     }
-
-    li {
-      border-top: 1px solid darken($borderblue, 30%);
-    }
-
-    ul.meta {
-      border-top: 1px solid darken($borderblue, 30%);
-
-      li {
-        border-top: none;
-      }
-
-      a {
-        color: #8CA2B8;
-      }
-    }
-
-    h2 {
-      color: $lightblue;
-    }
-
-    .back {
-      span {
-        color: $lightblue;
-
-        &:before {
-          content: '<';
-          float: left;
-          font-size: 20px;
-          font-weight: 100;
-          line-height: 1;
-          padding-right: 10px;
-        }
-
-        &::before {
-          -ms-transform: rotate(0deg);
-        }
-      }
-    }
-
-    .parent:after {
-      content: '>';
-      float: right;
-      font-size: 20px;
-      font-weight: 100;
-      line-height: 1;
-      z-index: 109;
-    }
-
-    .parent::after {
-      -ms-transform: rotate(0deg);
-      z-index: 1;
-    }
-
-    &.active {
-      display: block;
-      position: fixed;
-      right: 0;
-      top: 0;
-      -ms-transform: none;
-      width: 300px;
-    }
-
-    .inner {
-      display: none;
-
-      &.active {
-        display: block;
-      }
+    
+    .w {
+      padding-right: 0;
+      width: $width-localnav;
     }
   }
 }

--- a/assets/targets/injection/nav/_localnav.scss
+++ b/assets/targets/injection/nav/_localnav.scss
@@ -38,7 +38,7 @@
     right: 0;
     z-index: 15;
 
-    .sitemap-label {
+    .sitemap-trigger {
       margin-left: -100px;
 
       @include breakpoint(tablet) {
@@ -311,7 +311,6 @@ body.ie {
       top: 0;
       -ms-transform: none;
       width: 300px;
-      z-index: 100;
     }
 
     .inner {

--- a/assets/targets/injection/nav/_modal.scss
+++ b/assets/targets/injection/nav/_modal.scss
@@ -60,10 +60,6 @@
       @extend %modal-close-icon;
     }
 
-    &::before {
-      @extend %modal-close-icon;
-    }
-
     &:hover {
       color: #444;
     }

--- a/assets/targets/injection/nav/_nav.scss
+++ b/assets/targets/injection/nav/_nav.scss
@@ -136,14 +136,6 @@ body {
       content: '';
       display: block;
     }
-
-    &::after {
-      @include rem(margin, 30px auto 15px);
-      @include rem(width, 80px);
-      border-bottom: 2px solid $black;
-      content: '';
-      display: block;
-    }
   }
 
   .half {
@@ -258,7 +250,7 @@ body {
     transform: rotate(90deg);
     z-index: 11;
 
-    &::before {
+    &:before {
       @include rem(font-size, 24px);
       content: '\203a';
       display: inline-block;
@@ -272,15 +264,15 @@ body {
 
 
 .ie {
-  .page-inner {
-    &.active {
-      -ms-transform: none;
-    }
-
-    &.global-active {
-      z-index: 0;
-    }
-  }
+//  .page-inner {
+//    &.active {
+//      -ms-transform: none;
+//    }
+//
+//    &.global-active {
+//      z-index: 0;
+//    }
+//  }
 
   .uomcontent .modal__dialog {
     left: 20%;

--- a/assets/targets/injection/nav/_nav.scss
+++ b/assets/targets/injection/nav/_nav.scss
@@ -2,17 +2,10 @@ body {
   overflow-x: hidden;
 }
 
-.uomcontent {
-  @extend %smooth-translate;
-}
-
 .page-inner {
-  @extend %smooth-translate;
-  // @include rem(padding-top, 60px);
-  background-color: $navy;
   min-height: 100%;
   position: relative;
-  z-index: 2;
+  z-index: 10;
 
   .floating {
     margin-top: -90px;
@@ -20,51 +13,6 @@ body {
 
   @include breakpoint(desktop) {
     @include rem(padding-top, 90px);
-  }
-
-  &.active {
-    @include translateX(-100%);
-    overflow: hidden;
-    position: fixed;
-    top: 0;
-    width: 100%;
-    z-index: 10;
-
-    @include breakpoint(tablet) {
-      @include translateX(-340px);
-    }
-  }
-
-  &.global-active {
-    @include translateX(-100%);
-    position: fixed;
-    top: 0;
-    width: 100%;
-
-    .modal__blanket.on {
-      position: absolute;
-    }
-
-    @include breakpoint(tablet) {
-      @include transform(translate(-100%, 0) translate(90px, 0));
-    }
-  }
-
-}
-
-.page-header {
-  @extend %smooth-translate;
-
-  &.active {
-    @include breakpoint(tablet) {
-      @include translateX(-340px);
-    }
-  }
-
-  &.global-active {
-    @include breakpoint(tablet) {
-      @include transform(translate(-100%, 0) translate(90px, 0));
-    }
   }
 }
 
@@ -272,6 +220,7 @@ body {
   @include rem(width, 50px);
   background-color: $navy;
   box-shadow: 3px 0 6px rgba($black, .4) inset;
+  color: rgba($white, .5);
   cursor: pointer;
   display: block;
   height: 100%;
@@ -279,7 +228,7 @@ body {
   right: -5px;
   top: 0;
   transform: translateX(100%);
-  transition: transform .3s ease;
+  transition: color .3s ease, $smooth-transform;
   z-index: 16;
 
   &.active {
@@ -287,12 +236,8 @@ body {
 
     &:hover {
       @include rem(width, 50px);
+      color: $white;
       transform: translateX(-5px);
-
-      span {
-        @include transition(color .3s ease);
-        color: $white;
-      }
     }
   }
 
@@ -301,9 +246,6 @@ body {
     @include rem(padding-left, 44px);
     @include rem(padding-top, 190px);
     @include rem(width, 240px);
-    @include transform(rotate(90deg));
-    color: rgba($white, .5);
-    cursor: pointer;
     font-weight: $light;
     left: 0;
     letter-spacing: 1px;
@@ -313,13 +255,17 @@ body {
     position: absolute;
     text-transform: uppercase;
     top: 0;
+    transform: rotate(90deg);
     z-index: 11;
 
     &::before {
       @include rem(font-size, 24px);
-      @include transform(rotate(-90deg) translateY(-10px) translateX(-3px));
       content: '\203a';
       display: inline-block;
+      left: -10px;
+      position: relative;
+      top: 3px;
+      transform: rotate(-90deg);
     }
   }
 }

--- a/assets/targets/injection/nav/_nav.scss
+++ b/assets/targets/injection/nav/_nav.scss
@@ -264,16 +264,6 @@ body {
 
 
 .ie {
-//  .page-inner {
-//    &.active {
-//      -ms-transform: none;
-//    }
-//
-//    &.global-active {
-//      z-index: 0;
-//    }
-//  }
-
   .uomcontent .modal__dialog {
     left: 20%;
     right: 20%;

--- a/assets/targets/injection/nav/_nav.scss
+++ b/assets/targets/injection/nav/_nav.scss
@@ -268,36 +268,32 @@ body {
   }
 }
 
-.uomcontent .sitemap-label {
-  @include rem(width, 45px);
-  @include transform(translate(100%, 0) translate(-45px, 0));
-  @include transition(width .3s ease, right .3s ease);
+.uomcontent .sitemap-trigger {
+  @include rem(width, 50px);
   background-color: $navy;
   box-shadow: 3px 0 6px rgba($black, .4) inset;
   cursor: pointer;
   display: block;
   height: 100%;
   position: fixed;
-  right: 0;
+  right: -5px;
   top: 0;
+  transform: translateX(100%);
+  transition: transform .3s ease;
   z-index: 16;
 
-  &:hover {
-    @include rem(right, 5px);
-    @include rem(width, 50px);
-
-    span {
-      @include transition(color .3s ease);
-      color: $white;
-    }
-  }
-
   &.active {
-    @include transform(translate(100%, 0));
-    @include transition(-moz-transform .3s ease);
-    @include transition(-ms-transform .3s ease);
-    @include transition(-webkit-transform .3s ease);
-    @include transition(transform .3s ease);
+    transform: translateX(0);
+
+    &:hover {
+      @include rem(width, 50px);
+      transform: translateX(-5px);
+
+      span {
+        @include transition(color .3s ease);
+        color: $white;
+      }
+    }
   }
 
   span {
@@ -388,7 +384,7 @@ body {
     }
   }
 
-  .uomcontent .sitemap-label {
+  .uomcontent .sitemap-trigger {
     display: none;
   }
 }

--- a/assets/targets/injection/nav/index.js
+++ b/assets/targets/injection/nav/index.js
@@ -143,22 +143,12 @@ InjectNav.prototype.update = function() {
   var both = activeNav.local && activeNav.global;
 
   this.props.blanket.toggle(either);
-  this.props.header.toggleClass('active', either);
-  this.props.page.toggleClass('active', either);
-
+  this.props.globalNav.toggleClass('active', activeNav.global);
+  
   if (this.props.localNav) {
     this.props.localNav.toggleClass('active', activeNav.local && !activeNav.global);
+    this.props.sitemapTrigger.toggleClass('active', activeNav.local);
   }
-
-  this.props.header.toggleClass('global-active', activeNav.global);
-  this.props.page.toggleClass('global-active', activeNav.global);
-  this.props.globalNav.toggleClass('active', activeNav.global);
-
-  this.props.sitemapTrigger.toggleClass('active', activeNav.local);
-
-//  this.props.localNav.toggleClass('global-active', activeNav.global); // TODO needed?
-//  this.props.header.toggleClass('fixed', either); // TODO needed if scrolling to top with `window.scrollTop(0, 0)`
-//  this.props.globalNav.toggleClass('reveal', activeNav.global); // TODO needed?
 };
 
 
@@ -169,7 +159,7 @@ InjectNav.prototype.handleSearchTrigger = function(e) {
 
 InjectNav.prototype.renderGlobalSitemap = function() {
   // Create global nav trigger
-  if (!this.props.sitemapTrigger) {
+  if (this.props.localNav && !this.props.sitemapTrigger) {
     this.props.sitemapTrigger = document.createElement('div');
     this.props.sitemapTrigger.setAttribute('class', 'sitemap-trigger');
     this.props.sitemapTrigger.innerHTML = '      <span>University Sitemap</span>';

--- a/assets/targets/injection/nav/index.js
+++ b/assets/targets/injection/nav/index.js
@@ -21,7 +21,7 @@ function InjectNav(props) {
     globalNav: document.querySelector('#globalsitemap'),
     menuTrigger: document.querySelector('.page-header-tools a[title="Menu"]'),
     searchTrigger: document.querySelector('.page-header-tools a[title="Search"]'),
-    sitemapTrigger: document.querySelector('.sitemap-label')
+    sitemapTrigger: document.querySelector('.sitemap-trigger')
   };
 
   // Add elements to props
@@ -154,7 +154,7 @@ InjectNav.prototype.update = function() {
   this.props.page.toggleClass('global-active', activeNav.global);
   this.props.globalNav.toggleClass('active', activeNav.global);
 
-  this.props.sitemapTrigger.toggleClass('active', !activeNav.local); // TODO should be the opposite (have `active` class when local nav is active)
+  this.props.sitemapTrigger.toggleClass('active', activeNav.local);
 
 //  this.props.localNav.toggleClass('global-active', activeNav.global); // TODO needed?
 //  this.props.header.toggleClass('fixed', either); // TODO needed if scrolling to top with `window.scrollTop(0, 0)`
@@ -171,7 +171,7 @@ InjectNav.prototype.renderGlobalSitemap = function() {
   // Create global nav trigger
   if (!this.props.sitemapTrigger) {
     this.props.sitemapTrigger = document.createElement('div');
-    this.props.sitemapTrigger.setAttribute('class', 'sitemap-label active');
+    this.props.sitemapTrigger.setAttribute('class', 'sitemap-trigger');
     this.props.sitemapTrigger.innerHTML = '      <span>University Sitemap</span>';
     this.props.root.appendChild(this.props.sitemapTrigger);
   }

--- a/assets/targets/injection/nav/index.scss
+++ b/assets/targets/injection/nav/index.scss
@@ -1,3 +1,8 @@
+// Variables
+$width-localnav: 300px;
+$width-sitemap-trigger: 45px;
+$offset-localnav: -($width-localnav + $width-sitemap-trigger);
+
 @import '../../../shared/blanket';
 @import 'modal';
 @import 'nav';

--- a/assets/targets/injection/nav/localnav.es6
+++ b/assets/targets/injection/nav/localnav.es6
@@ -50,33 +50,27 @@ LocalNav.prototype.moveLocalNav = function() {
     this.props.localnav.removeClass('no-js');
     this.props.root.appendChild(this.props.localnav);
 
-    var elements = [];
-    for (var groups=this.props.localnav.querySelectorAll('.inner'), i=groups.length - 1; i >= 0; i--) {
-      elements.push(groups[i]);
-    }
+    var innerElements = this.props.localnav.querySelectorAll('.inner');
+    var innerElem, parent, back, handler;
+    
+    for (i = innerElements.length - 1; i >= 0; i--) {
+      innerElem = innerElements[i];
+      handler = toggleActive.bind(this, innerElem);
+      
+      parent = innerElem.parentNode.querySelector('a');
+      parent.addClass('parent');
+      parent.addEventListener('click', handler);
 
-    for (i=elements.length - 1; i >= 0; i--) {
-      var childgroup = elements[i], parent = childgroup.parentNode.querySelector('a');
-      childgroup.addClass('hide');
-
-      var back = document.createElement('span');
+      back = document.createElement('span');
       back.addClass('back');
       back.innerHTML = parent.textContent || parent.innerText;
-      childgroup.insertBefore(back, childgroup.firstChild);
+      back.addEventListener('click', handler);
+      innerElem.insertBefore(back, innerElem.firstChild);
+    }
 
-      back.addEventListener('click', function(e) {
-        e.preventDefault();
-        this.parentNode.toggleClass('hide');
-        this.parentNode.toggleClass('active');
-      });
-
-      parent.addClass('parent');
-      parent.addEventListener('click', function(e) {
-        e.preventDefault();
-        var div = this.parentNode.querySelector('div');
-        div.toggleClass('hide');
-        div.toggleClass('active');
-      });
+    function toggleActive(elem, evt) {
+      evt.preventDefault();
+      elem.toggleClass('active');
     }
   }
 };

--- a/assets/targets/injection/nav/localnav.es6
+++ b/assets/targets/injection/nav/localnav.es6
@@ -71,6 +71,8 @@ LocalNav.prototype.moveLocalNav = function() {
     function toggleActive(elem, evt) {
       evt.preventDefault();
       elem.toggleClass('active');
+      this.props.localnav.scrollTop = 0;
+      this.props.localnav.toggleClass('inner-open');
     }
   }
 };

--- a/assets/targets/injection/patterns.scss
+++ b/assets/targets/injection/patterns.scss
@@ -2,18 +2,6 @@
 @import '../../shared/patterns_media-queries';
 @import '../../shared/patterns_accessibility';
 
-// X-axis translation
-@mixin translateX($d) {
-  -moz-transform: translate3d($d, 0, 0);
-  -ms-transform: translate3d($d, 0, 0);
-  -webkit-transform: translate3d($d, 0, 0);
-  transform: translate3d($d, 0, 0);
-  -moz-transition: -moz-transform .3s ease;
-  -ms-transition: -ms-transform .3s ease;
-  -webkit-transition: -webkit-transform .3s ease;
-  transition: transform .3s ease;
-}
-
 // Wrapper
 %wrapper {
   @include rem(max-width, 1400px);
@@ -50,13 +38,6 @@
   background-position: top center;
   background-repeat: no-repeat;
   background-size: cover;
-}
-
-%smooth-translate {
-  -moz-transition: -moz-transform .3s ease;
-  -ms-transition: -ms-transform .3s ease;
-  -webkit-transition: -webkit-transform .3s ease;
-  transition: transform .3s ease;
 }
 
 %normalise {


### PR DESCRIPTION
Fixes #438. Let local and global nav fly over the page rather than push it. Reasons and benefits:

1. Brings much better performance and looks better visually, as the page's header and inner elements were always slightly out of sync during the animations.
2. Fixes #440: the page no longer jumps back to the top when the nav is opened. This was a significant issue in Pursuit.
3. The (dis)appearance of the page's scrollbar was causing a slight jag. Now, when the nav is opened, the scrollbar remains visible and the page scrollable.

Additional improvements and fixes:
- remove transform and transition mixins; let autoprefixer do its job
- declare styles like `transition` and `z-index` in the normal state of an element instead of in its active state
- similarly, ensure that a `transform` declaration exists in the normal state, even if it is `transform: translateX(0)` - this lets the browser create a new composition layer/stacking context in advance
- fix strange space below the overlay/blanket
- fix sub-menus not covering parent local nav (fixes #517)