### PR TITLE
Fix Photoswipe library loaded more than once

### DIFF
--- a/assets/targets/components/gallery/00-overview.md
+++ b/assets/targets/components/gallery/00-overview.md
@@ -2,4 +2,4 @@
 title: Gallery
 ---
 
-Please note: this component will not work on IE8 and below, since it depends on SVG and incompatible 3rd party Javsascript.
+Please note: this component will not work on IE8 and below, since it depends on SVG and incompatible 3rd party JavsaScript.

--- a/assets/targets/components/gallery/index.js
+++ b/assets/targets/components/gallery/index.js
@@ -6,7 +6,7 @@
  */
 function ImageGallery(el, props) {
   this.el = el;
-  this.props = props;
+  this.props = props || {};
 
   this.setupPhotoSwipe();
   this.setupGallery();
@@ -20,8 +20,8 @@ function ImageGallery(el, props) {
       gutter: 0
     }
   });
-
-  loadScript('https://d2h9b02ioca40d.cloudfront.net/shared/photoswipe.pkgd.min.js', this.initPhotoSwipeFromDOM.bind(this));
+  
+  this.initPhotoSwipeFromDOM();
 }
 
 /**

--- a/assets/targets/components/index.js
+++ b/assets/targets/components/index.js
@@ -68,7 +68,7 @@ window.UOMloadComponents = function() {
   "use strict";
 
   var recs, i, g, SidebarTabs, JumpNav, CheckboxHelper, FancySelect,
-    ImageGallery, imagesLoaded, slingshot, LMaps, style, script;
+    ImageGallery, imagesLoaded, LMaps, slingshot, style, script;
 
   window.UOMbind('accordion');
   window.UOMbind('modal');
@@ -123,18 +123,19 @@ window.UOMloadComponents = function() {
 
     recs = document.querySelectorAll('ul.image-gallery');
     if (recs.length > 0) {
-      imagesLoaded = require("imagesloaded");
-      ImageGallery = require("./gallery");
+      loadScript('https://d2h9b02ioca40d.cloudfront.net/shared/photoswipe.pkgd.min.js', function (recs) {
+        imagesLoaded = require("imagesloaded");
+        ImageGallery = require("./gallery");
 
-      slingshot = function() {
-        new ImageGallery(this, {});
-      };
-
-      for (i=recs.length - 1; i >= 0; i--) {
-        g = recs[i];
-
-        imagesLoaded(g, slingshot.bind(g));
-      }
+        slingshot = function (g) {
+          new ImageGallery(g);
+        };
+        
+        for (i=recs.length - 1; i >= 0; i--) {
+          g = recs[i];
+          imagesLoaded(g, slingshot.bind(null, g));
+        }
+      }.bind(null, recs));
     }
 
     recs = document.querySelectorAll('[data-leaflet-latlng]');

--- a/assets/targets/debranded/index.js
+++ b/assets/targets/debranded/index.js
@@ -127,18 +127,19 @@ window.DSComponentsLoad = function() {
 
   recs = document.querySelectorAll('ul.image-gallery');
   if (recs.length > 0) {
-    imagesLoaded = require('imagesloaded');
-    ImageGallery = require("../components/gallery");
+    loadScript('https://d2h9b02ioca40d.cloudfront.net/shared/photoswipe.pkgd.min.js', function (recs) {
+      imagesLoaded = require('imagesloaded');
+      ImageGallery = require("../components/gallery");
 
-    slingshot = function() {
-      new ImageGallery(this, {});
-    };
+      slingshot = function (g) {
+        new ImageGallery(g);
+      };
 
-    for (i=recs.length - 1; i >= 0; i--) {
-      g = recs[i];
-
-      imagesLoaded(g, slingshot.bind(g));
-    }
+      for (i=recs.length - 1; i >= 0; i--) {
+        g = recs[i];
+        imagesLoaded(g, slingshot.bind(null, g));
+      }
+    }.bind(null, recs));
   }
 
   recs = document.querySelectorAll('[data-leaflet-latlng]');


### PR DESCRIPTION
Move loading of `photoswipe.js` with `loadScript` outside of the `ImageGallery` class to ensure it is never loaded more than once (i.e. when multiple galleries are used on the same page).