### PR TITLE
Fix icons with hidden label on IE8

### DIFF
--- a/assets/targets/components/icons/_svg.scss
+++ b/assets/targets/components/icons/_svg.scss
@@ -48,16 +48,6 @@
       }
     }
 
-    &.icon--hide-label {
-      // Fix outline bug in Chrome
-      overflow: hidden;
-      position: relative;
-      
-      & > .icon-label {
-        @include screenreaders-only;
-      }
-    }
-
     .icon-label {
       font-weight: $regular;
       margin: 0;
@@ -80,11 +70,23 @@
   }
 }
 
+:not(.ie8) {
+  .uomcontent [data-icon].icon--hide-label {
+    // Fix outline bug in Chrome
+    overflow: hidden;
+    position: relative;
+
+    & > .icon-label {
+      @include screenreaders-only;
+    }
+  }
+}
+
 .ie8 .uomcontent {
   [data-icon],
   [data-icon].fill,
   [data-icon].small,
   [data-icon].large {
-    width: auto;
+    width: auto!important;
   }
 }


### PR DESCRIPTION
Since SVG icons do not work on IE8, labels must always be shown.