### PR TITLE
Allow adding multiple pins to a gmap

### DIFF
--- a/assets/targets/components/index.js
+++ b/assets/targets/components/index.js
@@ -142,7 +142,7 @@ window.UOMloadComponents = function() {
       loadScript('https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.3/leaflet.js', function() {
         style = document.createElement('link');
         style.rel = 'stylesheet';
-        style.href = 'http://cdn.leafletjs.com/leaflet-0.7.3/leaflet.css';
+        style.href = 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.3/leaflet.css';
         document.body.appendChild(style);
 
         LMaps = require("./maps/lmaps");

--- a/assets/targets/components/maps/04-pin.slim
+++ b/assets/targets/components/maps/04-pin.slim
@@ -1,2 +1,0 @@
-section
-  .map-canvas data-pin="-37.798535, 144.960605" data-latlng="-37.798535, 144.960605"

--- a/assets/targets/components/maps/04-pins.slim
+++ b/assets/targets/components/maps/04-pins.slim
@@ -1,0 +1,3 @@
+p You can add multiple pins to the map by separating their coordinates with pipes (<code>|</code>) inside the <code>data-pin</code> attribute.
+section
+  .map-canvas data-pin="-37.798535, 144.960605|-37.798048, 144.960946" data-latlng="-37.798535, 144.960605"

--- a/assets/targets/components/maps/07-openstreetmap.slim
+++ b/assets/targets/components/maps/07-openstreetmap.slim
@@ -1,2 +1,2 @@
 section
-  .map-canvas data-pin="-37.798535, 144.960605" data-leaflet-latlng="-37.798535, 144.960605" data-zoom="17"
+  .map-canvas data-pin="-37.798535, 144.960605|-37.798048, 144.960946" data-leaflet-latlng="-37.798535, 144.960605" data-zoom="17"

--- a/assets/targets/components/maps/gmaps.js
+++ b/assets/targets/components/maps/gmaps.js
@@ -11,7 +11,7 @@ function GMaps(el, props) {
   this.props.width = parseInt(this.el.getAttribute('data-width')) || 400;
   this.props.height = parseInt(this.el.getAttribute('data-height')) || 300;
   this.props.zoom = parseInt(this.el.getAttribute('data-zoom')) || 17;
-  this.props.pin = this.el.getAttribute('data-pin');
+  this.props.pins = this.el.getAttribute('data-pin');
 
   if (this.el.hasAttribute('data-latlng')) {
     // ES6 ;_; [this.props.lat, this.props.lng] = this.el.getAttribute('data-latlng').split(',');
@@ -37,11 +37,13 @@ GMaps.prototype.draw = function() {
   this.el.style.height = this.props.height + 'px';
   this.props.map = new google.maps.Map(this.el, this.props.options);
 
-  if (this.el.getAttribute('data-pin'))
-    this.marker();
+  if (this.props.pins) {
+    this.markers();
+  }
 
-  if (this.el.hasAttribute('data-grayscale'))
+  if (this.el.hasAttribute('data-grayscale')) {
     this.stylemap();
+  }
 };
 
 GMaps.prototype.geolookup = function() {
@@ -61,12 +63,15 @@ GMaps.prototype.handleResult = function(results, status) {
   }
 };
 
-GMaps.prototype.marker = function() {
-  var ll = this.props.pin.split(',');
-  new google.maps.Marker({
-    map:      this.props.map,
-    position: new google.maps.LatLng(ll[0], ll[1])
-  });
+GMaps.prototype.markers = function() {
+  var pins = this.props.pins.split('|');
+  for (var i = pins.length - 1; i >= 0; i--) {
+    var ll = pins[i].split(',');
+    new google.maps.Marker({
+      map:      this.props.map,
+      position: new google.maps.LatLng(ll[0], ll[1])
+    });
+  }
 };
 
 GMaps.prototype.stylemap = function() {

--- a/assets/targets/components/maps/lmaps.js
+++ b/assets/targets/components/maps/lmaps.js
@@ -10,6 +10,7 @@ function LMaps(el, props) {
 
   this.props.latlng = this.el.getAttribute('data-leaflet-latlng').split(',');
   this.props.zoom = parseInt(this.el.getAttribute('data-zoom')) || 15;
+  this.props.pins = this.el.getAttribute('data-pin');
 
   this.props.map = L.map(this.el);
   this.props.map.setView(this.props.latlng, this.props.zoom);
@@ -21,8 +22,12 @@ function LMaps(el, props) {
       accessToken: 'pk.eyJ1IjoidW5pbWVsYiIsImEiOiJjaWZ4Z3c5ZXo0M2R3dTdseGx0NXFyMmdiIn0.RIIkc7B1AboZclV3-JM5bA'
   }).addTo(this.props.map);
 
-  if (this.el.getAttribute('data-pin')) {
-    L.marker(this.el.getAttribute('data-pin').split(',')).addTo(this.props.map);
+  
+  if (this.props.pins) {
+    var pins = this.props.pins.split('|');
+    for (var i = pins.length - 1; i >= 0; i--) {
+      L.marker(pins[i].split(',')).addTo(this.props.map);
+    }
   }
 }
 


### PR DESCRIPTION
Fixes #524 

The `data-pin` attribute now accepts pairs of coordinates separated by pipes (`|`) - e.g. `data-pin="-37.798535, 144.960605|-37.798048, 144.960946"`

Also, fix mixed content issue on `https://web.unimelb.edu.au` by loading `leaflet.css` from `cdnjs`, which supports HTTPS.