### PR TITLE
Fix centre-aligned edge case FF search result

### DIFF
--- a/assets/targets/components/search/_search-results.scss
+++ b/assets/targets/components/search/_search-results.scss
@@ -17,7 +17,7 @@
     padding-left: 0;
     padding-right: 0;
     width: 94%;
-    
+
     @include breakpoint(desktop) {
       width: 100%;
     }
@@ -34,45 +34,46 @@
       &:last-child {
         @include padding-trailer(1);
       }
-      
+
       &.person {
         @extend %fallbackAvatarWrapper;
-        
+
         /* work-around for `with-aside` layout */
         div {
           clear: none;
           width: auto;
         }
-        
+
         .person__photo {
           background-position: center;
           background-size: cover;
           border-radius: 50%;
           width: 85px;
           height: 85px;
-      
+
           /* When using the background-image technique, show a fallback avatar if the photo fails to load */
           &:not(img) {
             @extend %fallbackAvatar;
           }
         }
-        
+
         .person__info {
+          margin-left: 0;
           overflow: hidden;
         }
-        
+
         .person__contact {
           @include padding-leader(0.5);
-          
+
           a {
             white-space: nowrap;
           }
         }
-        
+
         .person__phone {
           @include adjust-font-size-to(18px);
         }
-        
+
         @include breakpoint(desktop) {
           .person__info {
             display: table;
@@ -83,17 +84,17 @@
             display: table-cell;
             vertical-align: top;
           }
-          
+
           .person__profile {
             @include rem(padding-right, 24px);
             width: 100%;
           }
-          
+
           .person__contact {
             padding-top: 0;
             text-align: right;
           }
-        
+
           .person__phone {
             @include adjust-font-size-to(20px);
             white-space: nowrap;
@@ -142,12 +143,12 @@
       &.url {
         @include adjust-font-size-to(12px);
         color: $highlight;
-        
+
         & > a {
           @extend %ellipsis;
         }
       }
-      
+
       &.more {
         @include padding-leader(0.5);
         clear: left;
@@ -159,11 +160,11 @@
           line-height: 0;
         }
       }
-      
+
       & > [data-icon="lock"] {
         @include rem(width, 20px);
         @include rem(height, 20px);
-        
+
         & > .icon-over {
           display: block;
         }

--- a/doc-site/views/example_layouts/search.slim
+++ b/doc-site/views/example_layouts/search.slim
@@ -181,6 +181,16 @@ div role="main"
                 .person__contact
                   p.person__phone: a href="tel:+61383440346" +61 3 8344 0346
                   p.person__email: a href="mailto:chaz-batrouney@unimelb.edu.au" chaz-batrouney@unimelb.edu.au
+            li.person
+              .person__photo style="background-image: url(//findanexpert.unimelb.edu.au/pictures/thumbnail195234picture);"
+              .person__info
+                .person__profile
+                  h3: a href="#" Chaz Batrouney
+                  p: em
+                  p Project Services
+                .person__contact
+                  p.person__phone: a href="tel: "
+                  p.person__email: a href="mailto: "
 
         .sidebar-tab#news
           h2.search-title News


### PR DESCRIPTION
Add margin override to force left align when missing contact detail content (needed on full search template, where `display:table` inherits from an outer `display:table`)

Doesn't seem to occur in webkit.