### PR TITLE
Revert to transparent on inner unit

### DIFF
--- a/assets/targets/components/tabs/_tabs.scss
+++ b/assets/targets/components/tabs/_tabs.scss
@@ -322,7 +322,7 @@
     }
 
     .half {
-      background-color: $lightgray;
+      background-color: transparent;
     }
 
     aside h2.subtitle {

--- a/assets/targets/components/tabs/_tabs.scss
+++ b/assets/targets/components/tabs/_tabs.scss
@@ -321,10 +321,6 @@
       @extend %clearfix;
     }
 
-    .half {
-      background-color: transparent;
-    }
-
     aside h2.subtitle {
       @include rem(padding-bottom, 5px);
     }


### PR DESCRIPTION
There was a very slight colour difference on a particular page due to legacy styles that were incorrectly left there after the university-general colour scheme was added.
