### PR TITLE
Fix propagation of click event on inpage tabs

### DIFF
--- a/assets/targets/components/tabs/index.js
+++ b/assets/targets/components/tabs/index.js
@@ -233,6 +233,11 @@ Tabs.prototype.handleArrowClick = function(direction) {
  * @param {Event} e
  */
 Tabs.prototype.handleClick = function(e) {
+  // Prevent default anchor click handler from being called
+  e.stopImmediatePropagation();
+  // Default action now has to be prevented too
+  e.preventDefault();
+  
   var target = e.target;
 
   // IE8/no-svg fallback


### PR DESCRIPTION
The default anchor click handler is sometimes called when clicking on in-page tabs. This leads to unwanted smooth scrolling. Stop immediate propagation of click event so that the default handler is never called.