### PR TITLE
Tabs: improve accessibility and fix misc. bugs

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,8 +1,8 @@
-### Expected behaviour
+#### Expected behaviour
 How you'd like or expect the design system to behave (include your name, department and why you need this issue resolved).
 
-### Actual behaviour
+#### Actual behaviour
 How the design system actually behaves.
 
-### Steps to reproduce
+#### Steps to reproduce
 Include as much information as possible - e.g. browser, URL, screenshots, etc.

--- a/assets/targets/components/buttons/_buttons.scss
+++ b/assets/targets/components/buttons/_buttons.scss
@@ -317,7 +317,7 @@
     margin: 0;
     padding: 0;
     
-    &::moz-focus-inner {
+    &::-moz-focus-inner {
       border: 0;
       padding: 0;
     }

--- a/assets/targets/components/tabs/_tabs.scss
+++ b/assets/targets/components/tabs/_tabs.scss
@@ -135,6 +135,7 @@
       height: 100%;
       position: absolute;
       top: 0;
+      z-index: 1;
 
       &[disabled] {
         cursor: default;

--- a/assets/targets/components/tabs/_tabs.scss
+++ b/assets/targets/components/tabs/_tabs.scss
@@ -140,6 +140,10 @@
         cursor: default;
         opacity: .5;
       }
+      
+      &:focus {
+        outline: 1px dotted $white;
+      }
     }
     .tab-arrow--left {
       @include rem(padding-right, 10px);

--- a/assets/targets/components/tabs/_tabs.scss
+++ b/assets/targets/components/tabs/_tabs.scss
@@ -118,6 +118,11 @@
       z-index: 5;
     }
 
+    /* show scrollbar when focused */
+    .ps-focus .ps-scrollbar-x-rail {
+      opacity: 1;
+    }
+
     /* left/right arrows when screen size is too small to fit all the tabs */
     .tab-arrow {
       @include rem(font-size, 30px);

--- a/assets/targets/components/tabs/_tabs.scss
+++ b/assets/targets/components/tabs/_tabs.scss
@@ -42,7 +42,7 @@
 
   .tabbed-nav {
     & > .full-width {
-      @include rem(height, 64px);
+      @include rem(height, $tabs-height);
       background-color: $darkblue;
       border-bottom: 1px solid transparent;
       position: relative;
@@ -64,7 +64,8 @@
 
       a {
         @include adjust-font-size-to(15px);
-        @include rem(line-height, 64px);
+        @include rem(line-height, $tabs-height - 2px); // leave 1px above and below for outline
+        @include rem(margin-top, 1px); // outline cont.
         @include rem(padding, 0 20px);
         color: rgba($white, .7);
         display: inline-block;
@@ -112,6 +113,7 @@
     .tabbed-nav__inner {
       @include rem(padding-bottom, 15px);
       position: relative;
+      z-index: 1;
     }
 
     .ps-scrollbar-x-rail {
@@ -135,7 +137,7 @@
       height: 100%;
       position: absolute;
       top: 0;
-      z-index: 1;
+      z-index: 2;
 
       &[disabled] {
         cursor: default;
@@ -255,7 +257,8 @@
     &.thin {
       nav a {
         @include adjust-font-size-to(13px);
-        @include rem(line-height, 64px);
+        @include rem(line-height, $tabs-height - 2px); // leave 1px above and below for outline
+        @include rem(margin-top, 1px); // outline cont.
         @include rem(padding, 0 15px);
       }
 

--- a/assets/targets/components/tabs/index.js
+++ b/assets/targets/components/tabs/index.js
@@ -256,7 +256,11 @@ Tabs.prototype.handleClick = function(e) {
       e.preventDefault();
       this.move(target, true);
       this.setLocation(target.getAttribute('href'));
-      smoothScrollTo(target);
+      
+      // If navigation tab, scroll
+      if (this.props.isNav) {
+        smoothScrollTo(target);
+      }
     }
   } else {
     this.move(target, true);

--- a/assets/targets/components/tabs/index.js
+++ b/assets/targets/components/tabs/index.js
@@ -53,7 +53,6 @@ Tabs.prototype.setup = function() {
   for (i=this.props.tabs.length - 1; i >= 0; i--) {
     tab = this.props.tabs[i];
     tab.addEventListener('click', this.handleClick.bind(this));
-    tab.addEventListener('focus', this.scrollToTab.bind(this, tab, false));
   }
 
   // Handle internal clicks
@@ -239,7 +238,6 @@ Tabs.prototype.handleClick = function(e) {
   // Prevent default anchor click handler from being called
   e.stopImmediatePropagation();
   // Default action now has to be prevented too
-  e.preventDefault();
   
   var target = e.target;
 
@@ -255,6 +253,7 @@ Tabs.prototype.handleClick = function(e) {
   if (target.hasAttribute('href')) {
     // go to href
     if (target.getAttribute('href').charAt(0) == '#') {
+      e.preventDefault();
       this.move(target, true);
       this.setLocation(target.getAttribute('href'));
       smoothScrollTo(target);

--- a/assets/targets/components/tabs/index.js
+++ b/assets/targets/components/tabs/index.js
@@ -257,6 +257,7 @@ Tabs.prototype.handleClick = function(e) {
     if (target.getAttribute('href').charAt(0) == '#') {
       this.move(target, true);
       this.setLocation(target.getAttribute('href'));
+      smoothScrollTo(target);
     }
   } else {
     this.move(target, true);

--- a/assets/targets/components/tabs/index.js
+++ b/assets/targets/components/tabs/index.js
@@ -278,19 +278,14 @@ Tabs.prototype.panelExists = function(hash) {
 
 Tabs.prototype.setLocation = function(hash) {
   if (this.props.isNav && this.panelExists(hash)) {
-    var pos = document.body.scrollTop, slug;
-
     if (hash.charAt(0) === '#') {
-      window.location.hash = hash.split('#')[1];
+      if (history.pushState) {
+        history.pushState({'title': document.title, 'url': hash}, document.title, hash);
+      } else {
+        window.location.hash = hash.substr(1);
+      }
     } else {
       window.location = hash;
-    }
-
-    document.body.scrollTop = pos;
-
-    if (history.pushState) {
-      slug = window.location.href;
-      history.pushState({'title': document.title, 'url': slug}, document.title, slug);
     }
   }
 };

--- a/assets/targets/components/tabs/index.js
+++ b/assets/targets/components/tabs/index.js
@@ -237,6 +237,7 @@ Tabs.prototype.handleClick = function(e) {
   // Prevent default anchor click handler from being called
   e.stopImmediatePropagation();
   // Default action now has to be prevented too
+  e.preventDefault();
   
   var target = e.target;
 
@@ -249,44 +250,55 @@ Tabs.prototype.handleClick = function(e) {
     return;
   }
   
-  if (target.hasAttribute('href')) {
-    // go to href
-    if (target.getAttribute('href').charAt(0) == '#') {
-      e.preventDefault();
-      this.move(target, true);
-      this.setLocation(target.getAttribute('href'));
-      
-      // If navigation tab, scroll
-      if (this.props.isNav) {
-        smoothScrollTo(target);
+  var href = target.getAttribute('href');
+  if (href.charAt(0) === '#') {
+    this.move(target, true);
+
+    // If navigation tab, scroll
+    if (this.props.isNav) {
+      smoothScrollTo(target);
+    }
+  }
+  
+  // Set page location
+  this.setLocation(href);
+};
+
+Tabs.prototype.panelExists = function(id) {
+  // Loop through panel IDs looking for a match
+  for (var i = this.props.panels.length - 1; i >= 0; i--) {
+    if (this.props.panels[i] === id) {
+      // Match found
+      return true;
+    }
+  }
+
+  // No match found
+  return false;
+};
+
+Tabs.prototype.setLocation = function(href) {
+  // Return if not navigational tabs
+  if (!this.props.isNav) {
+    return;
+  }
+  
+  if (href.charAt(0) === '#') {
+    // Hash link; get ID of target
+    var targetId = href.substr(1);
+    
+    // If a panel exists with this ID, set location
+    if (this.panelExists(targetId)) {
+      // Use History API if available to prevent unwanted jump scroll
+      if (history.pushState) {
+        history.pushState({'title': document.title, 'url': href}, document.title, href);
+      } else {
+        window.location.hash = href;
       }
     }
   } else {
-    this.move(target, true);
-  }
-};
-
-Tabs.prototype.panelExists = function(hash) {
-  var exists = false;
-
-  for (max=this.props.panels.length, i=0; i < max; i++)
-    if (hash.substr(1) === this.props.panels[i])
-      exists = true;
-
-  return exists;
-};
-
-Tabs.prototype.setLocation = function(hash) {
-  if (this.props.isNav && this.panelExists(hash)) {
-    if (hash.charAt(0) === '#') {
-      if (history.pushState) {
-        history.pushState({'title': document.title, 'url': hash}, document.title, hash);
-      } else {
-        window.location.hash = hash.substr(1);
-      }
-    } else {
-      window.location = hash;
-    }
+    // External link; set location
+    window.location = href;
   }
 };
 

--- a/assets/targets/components/tabs/index.js
+++ b/assets/targets/components/tabs/index.js
@@ -41,7 +41,8 @@ function Tabs(el, props) {
  * Set up the tab panels and event listeners.
  */
 Tabs.prototype.setup = function() {
-  var recs, i, tabs;
+  var recs, i, tabs, tab;
+  
   // Hide all tabs by default
   for (recs=this.el.querySelectorAll('[role="tabpanel"]'), i=recs.length - 1; i >= 0; i--) {
     recs[i].style.display = 'none';
@@ -50,7 +51,9 @@ Tabs.prototype.setup = function() {
 
   // Handle clicks on tabs
   for (i=this.props.tabs.length - 1; i >= 0; i--) {
-    this.props.tabs[i].addEventListener('click', this.handleClick.bind(this));
+    tab = this.props.tabs[i];
+    tab.addEventListener('click', this.handleClick.bind(this));
+    tab.addEventListener('focus', this.scrollToTab.bind(this, tab, false));
   }
 
   // Handle internal clicks

--- a/assets/targets/components/tabs/index.js
+++ b/assets/targets/components/tabs/index.js
@@ -41,7 +41,7 @@ function Tabs(el, props) {
  * Set up the tab panels and event listeners.
  */
 Tabs.prototype.setup = function() {
-  var recs, i, tabs, tab;
+  var recs, i, tabs;
   
   // Hide all tabs by default
   for (recs=this.el.querySelectorAll('[role="tabpanel"]'), i=recs.length - 1; i >= 0; i--) {
@@ -51,8 +51,7 @@ Tabs.prototype.setup = function() {
 
   // Handle clicks on tabs
   for (i=this.props.tabs.length - 1; i >= 0; i--) {
-    tab = this.props.tabs[i];
-    tab.addEventListener('click', this.handleClick.bind(this));
+    this.props.tabs[i].addEventListener('click', this.handleClick.bind(this));
   }
 
   // Handle internal clicks

--- a/assets/targets/components/tabs/index.js
+++ b/assets/targets/components/tabs/index.js
@@ -261,7 +261,6 @@ Tabs.prototype.handleClick = function(e) {
     }
   } else {
     this.move(target, true);
-    this.setLocation(target.getAttribute('href'));
   }
 };
 

--- a/assets/targets/components/tabs/index.js
+++ b/assets/targets/components/tabs/index.js
@@ -159,8 +159,8 @@ Tabs.prototype.setupOverflow = function() {
   this.props.rightArrow = rightArrow;
   
   // Append wrapper and arrows
-  this.props.navParent.appendChild(inner);
   this.props.navParent.appendChild(leftArrow);
+  this.props.navParent.appendChild(inner);
   this.props.navParent.appendChild(rightArrow);
   
   // Listen for clicks on arrows

--- a/assets/targets/components/tabs/index.scss
+++ b/assets/targets/components/tabs/index.scss
@@ -1,2 +1,4 @@
+$tabs-height: 64px;
+
 @import '~perfect-scrollbar/dist/css/perfect-scrollbar.css';
 @import 'tabs';


### PR DESCRIPTION
#### Accessibility improvements
- show horizontal scrollbar when it receives focus
- fix/remove moz-inner-focus and add proper focus outline to arrows
- append left arrow before tabs to match visual order
- work around cropped focus outline on tabs (because of `overflow: hidden` on parent)

#### Bug fixes
- fix regressions introduced by #551 :
  - smooth scroll to tab bar on click (but only for navigational tabs)
  - follow external links
- fix smooth scroll to tab bar when clicking a tab in Firefox - fixes #554 
- more generally, refactor click handling code to remove all side effects