### PR TITLE
Fix gradient background on tabs arrows

### DIFF
--- a/assets/targets/components/tabs/_tabs.scss
+++ b/assets/targets/components/tabs/_tabs.scss
@@ -138,12 +138,12 @@
     }
     .tab-arrow--left {
       @include rem(padding-right, 10px);
-      background: linear-gradient(to left, transparent, rgba($darkblue, .9) 10%);
+      background: linear-gradient(to left, rgba($darkblue, 0), rgba($darkblue, .9) 10%);
       left: 0;
     }
     .tab-arrow--right {
       @include rem(padding-left, 10px);
-      background: linear-gradient(to right, transparent, rgba($darkblue, .9) 10%);
+      background: linear-gradient(to right, rgba($darkblue, 0), rgba($darkblue, .9) 10%);
       right: 0;
     }
 


### PR DESCRIPTION
Fixes #552

Safari behaves like `transparent` is actually `rgba($black, 0)`...