### PR TITLE
Fix loose inheritance on accordion container

### DIFF
--- a/assets/targets/components/accordion/02-single-block-open.slim
+++ b/assets/targets/components/accordion/02-single-block-open.slim
@@ -7,6 +7,14 @@ ul.accordion data-single-focus=""
     span.accordion__title Id sit explicari
     .accordion__hidden
       p Qui impetus tibique maluisset ne, omnes persequeris in vis. Ei his sonet suscipit oportere, harum debitis consequuntur ei vix. Cu semper omnium scaevola eum, mei an ferri honestatis referrentur. Eu vim invidunt dissentiet, ne ludus repudiare necessitatibus vim. Enim errem conceptam mel ex, epicuri scaevola complectitur nam ne.
+      ul
+        li Qui impetus tibique
+        li maluisset ne, omnes
+        li persequeris in vis.
+      ol
+        li Qui impetus tibique
+        li maluisset ne, omnes
+        li persequeris in vis.
   li
     span.accordion__title Mea in soleat altera
     .accordion__hidden

--- a/assets/targets/components/accordion/_accordion.scss
+++ b/assets/targets/components/accordion/_accordion.scss
@@ -48,6 +48,14 @@
       padding: 0;
       width: 100%;
 
+      ul li {
+        list-style-type: disc;
+      }
+
+      ol li {
+        list-style-type: decimal;
+      }
+
       p {
         width: 100%;
       }
@@ -59,17 +67,17 @@
         @include rem(padding-right, 15px);
         display: block;
         position: relative;
-        
+
         &:hover {
           color: $cyan;
           text-decoration: underline;
         }
-        
+
         &:focus {
           color: $cyan;
           outline: 0;
         }
-        
+
         &:before {
           @include rem(font-size, 18px);
           @include rem(left, 15px);
@@ -114,7 +122,7 @@
             transform: rotate(45deg);
           }
         }
-        
+
         .accordion__hidden {
           display: block;
         }
@@ -175,7 +183,7 @@
     .accordion__title:before {
       font-size: 18px;
     }
-    
+
     &.accordion__visible .accordion__title:before {
       font-size: 16px;
       content: "x";


### PR DESCRIPTION
Ideally, we want to get away from using the `ul > li` relationship for accordions altogether, but that will be a refactor for another day.

Fix #556 