### PR TITLE
Fix reload problems on both mapping solutions

### DIFF
--- a/assets/targets/components/index.js
+++ b/assets/targets/components/index.js
@@ -73,7 +73,7 @@ window.UOMloadComponents = function() {
   "use strict";
 
   var recs, i, g, SidebarTabs, JumpNav, CheckboxHelper, FancySelect, Flash,
-    ImageGallery, imagesLoaded, slingshot, LMaps, style, script;
+    ImageGallery, imagesLoaded, slingshot, style, script;
 
   window.UOMbind('accordion');
   window.UOMbind('modal');
@@ -155,26 +155,31 @@ window.UOMloadComponents = function() {
 
     recs = document.querySelectorAll('[data-leaflet-latlng]');
     if (recs.length > 0) {
-      loadScript('https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.3/leaflet.js', function() {
-        style = document.createElement('link');
-        style.rel = 'stylesheet';
-        style.href = 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.3/leaflet.css';
-        document.body.appendChild(style);
-
-        LMaps = require("./maps/lmaps");
-        for (i=recs.length - 1; i >= 0; i--) {
-          new LMaps(recs[i], {});
-        }
-      });
+      if (typeof(L) === 'undefined') {
+        loadScript('https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.3/leaflet.js', function() {
+          style = document.createElement('link');
+          style.rel = 'stylesheet';
+          style.href = 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.3/leaflet.css';
+          document.body.appendChild(style);
+          window.bound_lmaps = [];
+          lmaps_loaded_go(recs);
+        });
+      } else {
+        lmaps_loaded_go(recs);
+      }
     }
   }
 
   // GMaps will load via callback
   if (document.countSelector('[data-latlng],[data-address]') > 0) {
-    script = document.createElement("script");
-    script.type = "text/javascript";
-    script.src = "https://maps.googleapis.com/maps/api/js?callback=maps_loaded_go";
-    document.body.appendChild(script);
+    if (typeof(google) === 'undefined') {
+      script = document.createElement("script");
+      script.type = "text/javascript";
+      script.src = "https://maps.googleapis.com/maps/api/js?callback=maps_loaded_go";
+      document.body.appendChild(script);
+    } else {
+      maps_loaded_go();
+    }
   }
 };
 
@@ -182,7 +187,14 @@ window.UOMloadComponents = function() {
 window.maps_loaded_go = function() {
   var GMaps = require("./maps/gmaps");
   for (var recs = document.querySelectorAll('[data-latlng],[data-address]'), i=recs.length - 1; i >= 0; i--)
-    new GMaps(recs[i], {});
+    new GMaps(recs[i], {counter: i});
+};
+
+// LMaps callback
+window.lmaps_loaded_go = function(recs) {
+  var LMaps = require("./maps/lmaps");
+  for (var i=recs.length - 1; i >= 0; i--)
+    new LMaps(recs[i], {counter: i});
 };
 
 // Execute when ready

--- a/assets/targets/components/maps/gmaps.js
+++ b/assets/targets/components/maps/gmaps.js
@@ -16,11 +16,10 @@ function GMaps(el, props) {
   if (this.el.hasAttribute('data-latlng')) {
     // ES6 ;_; [this.props.lat, this.props.lng] = this.el.getAttribute('data-latlng').split(',');
     var ll = this.el.getAttribute('data-latlng').split(',');
-    this.props.lat = ll[0];
-    this.props.lng = ll[1];
+    this.props.latlng = new google.maps.LatLng(ll[0], ll[1]);
 
     this.props.options = {
-      center:      new google.maps.LatLng(this.props.lat, this.props.lng),
+      center:      this.props.latlng,
       zoom:        this.props.zoom,
       scrollwheel: false,
       mapTypeId:   google.maps.MapTypeId.ROADMAP
@@ -35,7 +34,8 @@ function GMaps(el, props) {
 GMaps.prototype.draw = function() {
   this.el.style.width = this.props.width + 'px';
   this.el.style.height = this.props.height + 'px';
-  this.props.map = new google.maps.Map(this.el, this.props.options);
+
+  this.maps = new google.maps.Map(this.el, this.props.options);
 
   if (this.props.pins) {
     this.markers();
@@ -81,8 +81,8 @@ GMaps.prototype.stylemap = function() {
     ]
   }];
   var styledMap = new google.maps.StyledMapType(styleOptions, { name: 'Styled Map' });
-  this.props.map.mapTypes.set('map_style', styledMap);
-  this.props.map.setMapTypeId('map_style');
+  this.maps.mapTypes.set('map_style', styledMap);
+  this.maps.setMapTypeId('map_style');
 };
 
 module.exports = GMaps;

--- a/assets/targets/components/maps/lmaps.js
+++ b/assets/targets/components/maps/lmaps.js
@@ -12,21 +12,23 @@ function LMaps(el, props) {
   this.props.zoom = parseInt(this.el.getAttribute('data-zoom')) || 15;
   this.props.pins = this.el.getAttribute('data-pin');
 
-  this.props.map = L.map(this.el);
-  this.props.map.setView(this.props.latlng, this.props.zoom);
+  if (window.bound_lmaps[this.props.counter] !== undefined)
+    window.bound_lmaps[this.props.counter].remove();
+
+  window.bound_lmaps[this.props.counter] = L.map(this.el);
+  window.bound_lmaps[this.props.counter].setView(this.props.latlng, this.props.zoom);
 
   L.tileLayer('https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}.png?access_token={accessToken}', {
       attribution: 'Map data &copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery © <a href="http://mapbox.com">Mapbox</a>',
       maxZoom: 18,
       id: 'unimelb.cifxgw7yf40guudlyrvtisese',
       accessToken: 'pk.eyJ1IjoidW5pbWVsYiIsImEiOiJjaWZ4Z3c5ZXo0M2R3dTdseGx0NXFyMmdiIn0.RIIkc7B1AboZclV3-JM5bA'
-  }).addTo(this.props.map);
+  }).addTo(window.bound_lmaps[this.props.counter]);
 
-  
   if (this.props.pins) {
     var pins = this.props.pins.split('|');
     for (var i = pins.length - 1; i >= 0; i--) {
-      L.marker(pins[i].split(',')).addTo(this.props.map);
+      L.marker(pins[i].split(',')).addTo(window.bound_lmaps[this.props.counter]);
     }
   }
 }


### PR DESCRIPTION
I ran into a number of reload problems with external libraries (gmaps & leaflet) not playing well with the live reloading editor I'm using in the next gen docs app - this fix should help with turbo links as well.