### PR TITLE
Fix modal position

### DIFF
--- a/assets/targets/components/modal/00-overview.md
+++ b/assets/targets/components/modal/00-overview.md
@@ -3,22 +3,19 @@ title: Modal
 ---
 <div class="jumpnav"></div>
 ## Overview
+A simple two&ndash;part modal component, with a triggering link and a modal container. Features:
 
-A simple two&ndash;part modal component, with a triggering link and a modal container.
-
-* Modal dialog is positioned at center of viewport, with an option to position 160px above triggering link
 * Will scroll and resize (mobile safe)
-* Clicking on the blanket (overlay) will close the modal, or you can include the optional close button in the top right corner
-* Allows multiple modals on the same page
-* Can have multiple triggers on the same modal
-* Use any content inside modal
+* May contain any amount and type of content
+* Close button inserted automatically
+* Clicking on the blanket (overlay) closes the modal
+* Multiple modals allowed on the same page
+
+## Positioning
+By default, the modal dialog is positioned at the center of the viewport. You may force the modal to appear 160px above the link by adding attribute `data-modal-offset` to the triggering link.
 
 ## Options
 <ul class="nobullet">
   <li><code>data-modal-target</code> &ndash; ID of modal to trigger <small>required</small></li>
-  <li><code>.modal__dialog</code> &ndash; Modal dialog container <small>required</small></li>
+  <li><code>data-modal-offset</code> &ndash; Forces the modal dialog to appear 160px above the triggering link (no value needed) <small>optional</small></li>
 </ul>
-
-**New!**
-
-Please note in the below examples, the close button is no longer required. The design system will insert it automatically.

--- a/assets/targets/components/modal/02-offset-positioning.slim
+++ b/assets/targets/components/modal/02-offset-positioning.slim
@@ -1,5 +1,5 @@
 p
-	a.button href="#" data-modal-target="test-modal2" Open a different modal
+	a.button href="#" data-modal-target="test-modal2" data-modal-offset=true Open a different modal
 div.modal__dialog id="test-modal2"
   h1 Here is another modal
   p You can also click outside the modal to close it

--- a/assets/targets/components/modal/_modal.scss
+++ b/assets/targets/components/modal/_modal.scss
@@ -35,7 +35,6 @@
       margin: 0 auto;
       max-width: 900px;
       right: 0;
-      top: 20%;
     }
   }
 

--- a/assets/targets/components/modal/index.js
+++ b/assets/targets/components/modal/index.js
@@ -8,7 +8,7 @@ function Modal(el, props) {
   this.el = el;
   this.props = props;
 
-  this.props.offset = el.getAttribute('data-modal-offset');
+  this.props.offset = el.hasAttribute('data-modal-offset');
 
   var CreateNameSpace = require('../../../shared/createnamespace');
   new CreateNameSpace();

--- a/assets/targets/components/modal/index.js
+++ b/assets/targets/components/modal/index.js
@@ -73,11 +73,12 @@ Modal.prototype.activateDialog = function(e) {
 
   if (this.props.offset) {
     this.props.targetElement.style.top = (this.el.offsetTop - 160) + 'px';
-
   } else {
     var viewport = document.body.getBoundingClientRect();
-    var top = parseInt( (window.height() - this.props.targetElement.offsetHeight) / 2 );
-    this.props.targetElement.style.top = (top - viewport.top) + 'px';
+    var top = parseInt((window.height() - this.props.targetElement.offsetHeight) / 2, 10);
+
+    // Postion the modal, making sure it never goes past the top of the viewport
+    this.props.targetElement.style.top = (Math.max(top, 40) - viewport.top) + 'px';
   }
 
   this.props.targetElement.classList.add('on');

--- a/assets/targets/injection/nav/_modal.scss
+++ b/assets/targets/injection/nav/_modal.scss
@@ -40,7 +40,6 @@
       margin: 0 auto;
       max-width: 900px;
       right: 0;
-      top: 20%;
     }
   }
 

--- a/assets/targets/injection/nav/_nav.scss
+++ b/assets/targets/injection/nav/_nav.scss
@@ -267,7 +267,6 @@ body {
   .uomcontent .modal__dialog {
     left: 20%;
     right: 20%;
-    top: 20%;
     width: 60%;
 
     .half .button-fill {


### PR DESCRIPTION
Fixes #571

- never position the modal above viewport top (40px minimum)
- update the documentation slightly
- document the `data-modal-offset` attribute and demonstrate its use in the second example