### PR TITLE
Workaround for breadcrumbs icon bug

### DIFF
--- a/assets/targets/injection/icons/_svg.scss
+++ b/assets/targets/injection/icons/_svg.scss
@@ -53,6 +53,10 @@
       margin: 0;
       text-align: center;
       white-space: nowrap;
+
+      .icon {
+        display: none; // Fix bug with v4.0 injection + v < 3.6 components
+      }
     }
 
     .icon-over {


### PR DESCRIPTION
Breadcrumb home icon gets duplicated when combining v4.0 injection + v3.5.2 (and below) components. This workaround consists of simply hiding the second icon... I think the only way to fix this will be to move the entire rebind logic to the injection and refactor it so that the components register themselves as being rebindable.

![double home](https://cloud.githubusercontent.com/assets/2936402/14238773/046b47c6-fa78-11e5-8f6a-f4daf84c6571.png)
