### PR TITLE
Fix icon helper bug

### DIFF
--- a/assets/targets/injection/icons/_svg.scss
+++ b/assets/targets/injection/icons/_svg.scss
@@ -53,10 +53,6 @@
       margin: 0;
       text-align: center;
       white-space: nowrap;
-
-      .icon {
-        display: none; // Fix bug with v4.0 injection + v < 3.6 components
-      }
     }
 
     .icon-over {

--- a/assets/targets/injection/icons/iconhelper.js
+++ b/assets/targets/injection/icons/iconhelper.js
@@ -8,14 +8,6 @@ function IconHelper(el, props) {
   this.el = el;
   this.props = props;
 
-  /*
-   * Check that UOMbind exists and that the icon hasn't been bound already.
-   *
-   * In v4.0, this IconHelper class was moved to the injection. As a result, in versions prior to 4.0, the helper gets called twice for each icon.
-   * This is fine as long as the helper checks the `data-bound` attribute to ensure the same icon doesn't get initialised twice.
-   * Unfortunately, this attribute was only added in v3.6 with `UOMbind`; hence the need to check that it exists.
-   * Without it, icons would get initialised twice in v3.5.2 and below.
-   */
   if (window.UOMbind && !this.el.hasAttribute('data-bound')) {
     if (MSIE_version > 8) {
       this.props.ref = this.el.getAttribute('data-icon');

--- a/assets/targets/injection/icons/iconhelper.js
+++ b/assets/targets/injection/icons/iconhelper.js
@@ -8,7 +8,7 @@ function IconHelper(el, props) {
   this.el = el;
   this.props = props;
 
-  if (window.UOMbind && !this.el.hasAttribute('data-bound')) {
+  if (!this.el.hasAttribute('data-bound')) {
     if (MSIE_version > 8) {
       this.props.ref = this.el.getAttribute('data-icon');
       if (this.props.ref.substr(0,5) != '#icon-') {

--- a/assets/targets/injection/icons/iconhelper.js
+++ b/assets/targets/injection/icons/iconhelper.js
@@ -8,7 +8,15 @@ function IconHelper(el, props) {
   this.el = el;
   this.props = props;
 
-  if (!this.el.hasAttribute('data-bound')) {
+  /*
+   * Check that UOMbind exists and that the icon hasn't been bound already.
+   *
+   * In v4.0, this IconHelper class was moved to the injection. As a result, in versions prior to 4.0, the helper gets called twice for each icon.
+   * This is fine as long as the helper checks the `data-bound` attribute to ensure the same icon doesn't get initialised twice.
+   * Unfortunately, this attribute was only added in v3.6 with `UOMbind`; hence the need to check that it exists.
+   * Without it, icons would get initialised twice in v3.5.2 and below.
+   */
+  if (window.UOMbind && !this.el.hasAttribute('data-bound')) {
     if (MSIE_version > 8) {
       this.props.ref = this.el.getAttribute('data-icon');
       if (this.props.ref.substr(0,5) != '#icon-') {

--- a/assets/targets/injection/index.js
+++ b/assets/targets/injection/index.js
@@ -18,7 +18,7 @@ window.UOMbindIcons = function() {
    * Unfortunately, this attribute was added only in v3.6 with `UOMbind`; hence the need to check that `UOMbind` exists.
    * Without it, icons would get initialised twice in v3.5.2 and below.
    */
-  if (!UOMbind) { return; }
+  if (!window.UOMbind) { return; }
 
   var recs, i, IconHelper;
 

--- a/assets/targets/injection/index.js
+++ b/assets/targets/injection/index.js
@@ -10,14 +10,24 @@ if (typeof window.MSIE_version === "undefined")
 window.UOMbindIcons = function() {
   "use strict";
 
-  var recs, i, Base;
+  /*
+   * Check that UOMbind exists.
+   *
+   * In v4.0, the IconHelper class was moved to the injection. As a result, in versions prior to 4.0, the helper gets called twice for each icon.
+   * This is fine as long as the helper checks the `data-bound` attribute to ensure the same icon doesn't get initialised twice.
+   * Unfortunately, this attribute was added only in v3.6 with `UOMbind`; hence the need to check that `UOMbind` exists.
+   * Without it, icons would get initialised twice in v3.5.2 and below.
+   */
+  if (!UOMbind) { return; }
+
+  var recs, i, IconHelper;
 
   recs = document.querySelectorAll('[data-icon]');
   if (recs.length > 0) {
-    Base = require('./icons/iconhelper.js');
+    IconHelper = require('./icons/iconhelper.js');
 
     for (i=recs.length - 1; i >= 0; i--)
-      new Base(recs[i], {});
+      new IconHelper(recs[i], {});
   }
 };
 


### PR DESCRIPTION
Check that UOMbind exists before executing UOMbindIcons.

In v4.0, the IconHelper class was moved to the injection. As a result, in versions prior to 4.0, the helper gets called twice for each icon. This is fine as long as the helper checks the `data-bound` attribute to ensure the same icon doesn't get initialised twice. Unfortunately, this attribute was added only in v3.6 with `UOMbind`; hence the need to check that `UOMbind` exists. Without it, icons would get initialised twice in v3.5.2 and below.