### PR TITLE
Trigger listening 3rd party code

### DIFF
--- a/assets/targets/components/tabs/index.js
+++ b/assets/targets/components/tabs/index.js
@@ -351,6 +351,28 @@ Tabs.prototype.move = function(target, smooth) {
       }
     }
   }
+
+  this.redraw();
+};
+
+// Trigger a resize event to activate 3rd party code
+Tabs.prototype.redraw = function() {
+  var e;
+  if (document.createEvent) {
+    e = document.createEvent("HTMLEvents");
+    e.initEvent("resize", true, true);
+  } else {
+    e = document.createEventObject();
+    e.eventType = "resize";
+  }
+
+  e.eventName = "resize";
+
+  if (document.createEvent) {
+    window.dispatchEvent(e);
+  } else {
+    window.fireEvent("on" + e.eventType, e);
+  }
 };
 
 Tabs.prototype.scrollToTab = function(tab, smooth) {


### PR DESCRIPTION
Create and fire a `resize` event to activate any 3rd party code listening for that event (gmaps, isotope).

At the moment this is only run in the tabs, might be useful in other areas too.

Fixes #208 