### PR TITLE
Reinstate missing border gap

### DIFF
--- a/assets/targets/components/pathfinder/_pathfinder.scss
+++ b/assets/targets/components/pathfinder/_pathfinder.scss
@@ -413,6 +413,19 @@
         }
       }
     }
+
+    &.soft {
+      @include breakpoint(desktop) {
+        li {
+          @include rem(padding-left, 1px);
+          text-align: left;
+
+          &:nth-child(2n+1) {
+            text-align: right;
+          }
+        }
+      }
+    }
   }
 
   .lead + .pathfinder-2,


### PR DESCRIPTION
It was overridden by the `-2` version.

Fixes #610 