### PR TITLE
Remove vendor prefixes

### DIFF
--- a/assets/shared/_globals.scss
+++ b/assets/shared/_globals.scss
@@ -62,31 +62,16 @@ $round-to-nearest-half-line: true;
 }
 
 %grad-bottom {
-  background: -moz-linear-gradient(top, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, .9) 100%); // /* FF3.6+ */
-  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, rgba(0, 0, 0, 0)), color-stop(100%, rgba(0, 0, 0, .9))); // /* Chrome,Safari4+ */
-  background: -webkit-linear-gradient(top, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, .9) 100%); // /* Chrome10+,Safari5.1+ */
-  background: -o-linear-gradient(top, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, .9) 100%); // /* Opera 11.10+ */
-  background: -ms-linear-gradient(top, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, .9) 100%); // /* IE10+ */
   background: linear-gradient(to bottom, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, .9) 100%); // /* W3C */
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#00000000', endColorstr='#cc000000', GradientType=0); // /* IE6-9 */
 }
 
 %grad-top {
-  background: -moz-linear-gradient(top, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, .9) 100%); // /* FF3.6+ */
-  background: -webkit-gradient(linear, left top, left bottom, color-stop(255%, rgba(255, 255, 255, 0)), color-stop(100%, rgba(255, 255, 255, .9))); // /* Chrome,Safari4+ */
-  background: -webkit-linear-gradient(top, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, .9) 100%); // // /* Chrome1255+,Safari5.1+ */
-  background: -o-linear-gradient(top, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, .9) 100%); // /* Opera 11.1255+ */
-  background: -ms-linear-gradient(top, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, .9) 100%); // /* IE1255+ */
   background: linear-gradient(to bottom, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, .9) 100%); // /* W3C */
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#FFFFFF', endColorstr='#FFFFFF', GradientType=0); // /* IE6-9 */
 }
 
 %grad-left {
-  background: -moz-linear-gradient(right, rgba($cyan, 0) 66%, rgba($cyan, .9) 100%); // /* FF3.6+ */
-  background: -webkit-gradient(linear, right top, left bottom, color-stop(66%, rgba($cyan, 0)), color-stop(100%, rgba($cyan, .9))); // /* Chrome,Safari4+ */
-  background: -webkit-linear-gradient(right, rgba($cyan, 0) 66%, rgba($cyan, .9) 100%); // /* Chrome10+,Safari5.1+ */
-  background: -o-linear-gradient(right, rgba($cyan, 0) 66%, rgba($cyan, .9) 100%); // /* Opera 11.10+ */
-  background: -ms-linear-gradient(right, rgba($cyan, 0) 66%, rgba($cyan, .9) 100%); // /* IE10+ */
   background: linear-gradient(to left, rgba($cyan, 0) 66%, rgba($cyan, .9) 100%); // /* W3C */
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#00000000', endColorstr='#cc000000', GradientType=1); // /* IE6-9 */
 }

--- a/assets/shared/_globals.scss
+++ b/assets/shared/_globals.scss
@@ -1,10 +1,3 @@
-@mixin appearance($a) {
-  -webkit-appearance: $a;
-  -moz-appearance: $a;
-  -ms-appearance: $a;
-  appearance: $a;
-}
-
 $black:         #000 !default;
 $darkgray:      #333;
 $midgray:       #666;

--- a/assets/shared/_globals.scss
+++ b/assets/shared/_globals.scss
@@ -108,9 +108,6 @@ $cdnurl: '//d2h9b02ioca40d.cloudfront.net/shared';
 }
 
 %normalise {
-  -moz-box-sizing: border-box;
-  -ms-box-sizing: border-box;
-  -webkit-box-sizing: border-box;
   box-sizing: border-box;
   margin: 0;
   padding: 0;

--- a/assets/shared/_patterns_normalize.scss
+++ b/assets/shared/_patterns_normalize.scss
@@ -25,11 +25,6 @@ li {
 }
 
 * {
-  /* autoprefixer: off */
-  -moz-box-sizing: border-box;
-  -ms-box-sizing: border-box;
-  -webkit-box-sizing: border-box;
-  /* autoprefixer: on */
   box-sizing: border-box;
 }
 

--- a/assets/targets/components/_print.scss
+++ b/assets/targets/components/_print.scss
@@ -237,13 +237,6 @@ $white: #ffffff;
         -webkit-appearance: menulist;
       }
 
-      h1.highlight {
-        background: $white !important;
-        color: $black !important;
-        -webkit-background-clip: inherit !important;
-        -webkit-text-fill-color: inherit !important;
-      }
-
       .alt,
       .with-aside aside,
       .tabbed-course .half,

--- a/assets/targets/components/base/_titles.scss
+++ b/assets/targets/components/base/_titles.scss
@@ -75,14 +75,11 @@
 .uomcontent [role="main"] {
   h1.highlight {
     @include adjust-font-size-to(75px);
-    background: -webkit-linear-gradient($navy, $highlight);
     color: $highlight;
     font-weight: $thin;
     letter-spacing: -5px;
     text-align: center;
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    -webkit-animation: hue 80s infinite linear;
+    animation: hue 80s infinite linear;
 
     @include breakpoint(desktop) {
       @include adjust-font-size-to(160px);
@@ -96,10 +93,7 @@
   header.banner h1.highlight,
   & > header.banner:first-child h1.highlight {
     @include adjust-font-size-to(60px);
-    background: -webkit-linear-gradient($highlight, lighten($highlight, 25%));
-    -webkit-background-clip: text;
     text-align: center;
-    -webkit-text-fill-color: transparent;
 
     @include breakpoint(desktop) {
       @include adjust-font-size-to(100px);

--- a/assets/targets/components/base/_typography.scss
+++ b/assets/targets/components/base/_typography.scss
@@ -1,11 +1,6 @@
-@-webkit-keyframes hue {
-  from {
-    -webkit-filter: hue-rotate(0deg);
-  }
-
-  to {
-    -webkit-filter: hue-rotate(-360deg);
-  }
+@keyframes hue {
+  from { filter: hue-rotate(0deg); }
+  to { filter: hue-rotate(-360deg); }
 }
 
 %ticks {
@@ -260,7 +255,7 @@
       @include breakpoint(wide) {
         & > li {
           @include rem(padding-left, 110px);
-          
+
           > * {
             margin-left: 0;
           }

--- a/assets/targets/components/listings/_block.scss
+++ b/assets/targets/components/listings/_block.scss
@@ -416,12 +416,11 @@
 
             span {
               background-color: $white;
+              box-decoration-break: clone;
               box-shadow: 10px 0 0 $white, -10px 0 0 $white;
               color: $highlight;
               font-weight: $bold;
               line-height: 1.2;
-
-              box-decoration-break: clone;
             }
 
             @include breakpoint(tablet) {
@@ -462,15 +461,13 @@
         strong {
           @include adjust-font-size-to(40px);
           background-color: $cyan;
+          box-decoration-break: clone;
           box-shadow: 10px 0 0 $cyan, -10px 0 0 $cyan;
           color: $white;
           display: inline;
           font-weight: $bold;
           line-height: 1.3;
           padding: 0;
-
-          -webkit-box-decoration-break: clone;
-          box-decoration-break: clone;
         }
       }
 

--- a/assets/targets/components/listings/_block.scss
+++ b/assets/targets/components/listings/_block.scss
@@ -292,9 +292,6 @@
     .event .crop-height::before {
       @include rem(height, 50px);
       @include rem(margin-top, -20px);
-      background: -moz-linear-gradient(to top, rgba(255, 255, 255, 1) 25%, rgba(255, 255, 255, 0) 100%);
-      background: -ms-linear-gradient(to top, rgba(255, 255, 255, 1) 25%, rgba(255, 255, 255, 0) 100%);
-      background: -webkit-linear-gradient(to top, rgba(255, 255, 255, 1) 25%, rgba(255, 255, 255, 0) 100%);
       background: linear-gradient(to top, rgba(255, 255, 255, 1) 25%, rgba(255, 255, 255, 0) 100%);
       content: ' ';
       display: block;
@@ -306,9 +303,6 @@
       @include rem(height, 80px);
       @include rem(margin-bottom, 9px);
       @include rem(margin-top, -91px);
-      background: -moz-linear-gradient(to top, rgba(255, 255, 255, 1) 25%, rgba(255, 255, 255, 0) 100%);
-      background: -ms-linear-gradient(to top, rgba(255, 255, 255, 1) 25%, rgba(255, 255, 255, 0) 100%);
-      background: -webkit-linear-gradient(to top, rgba(255, 255, 255, 1) 25%, rgba(255, 255, 255, 0) 100%);
       background: linear-gradient(to top, rgba(255, 255, 255, 1) 25%, rgba(255, 255, 255, 0) 100%);
       content: ' ';
       display: block;

--- a/assets/targets/components/pathfinder/_pathfinder.scss
+++ b/assets/targets/components/pathfinder/_pathfinder.scss
@@ -105,8 +105,9 @@
         padding-left: 0;
         padding-right: 0;
 
-        &:hover, &:focus {
-            background-color: $white;
+        &:hover,
+        &:focus {
+          background-color: $white;
         }
 
         strong {
@@ -115,11 +116,9 @@
           border-bottom: 0 none;
           color: $black;
 
-
           & > span {
             @include rem(padding, 0px 10px);
             transform: translateY(-50%);
-            -webkit-transform: translateY(-50%);
 
             span {
               @include trailer(0.5);
@@ -135,7 +134,6 @@
               content: '\2192';
               display: inline-block;
               line-height: 0;
-              // vertical-align: middle;
             }
           }
         }
@@ -176,8 +174,6 @@
       display: block;
       padding-top: 0;
       text-align: center;
-      // -webkit-transform: translate3d(0, 0, 0);
-      // -webkit-transform-style: preserve-3d;
       -webkit-font-smoothing: subpixel-antialiased;
     }
 
@@ -496,9 +492,8 @@
 
 .ie9 {
   .uomcontent .pathfinder .button-small {
-    -ms-transform: translateX(-50%);
-    transform: translateX(-50%);
     left: 50%;
+    transform: translateX(-50%);
     width: auto;
   }
 }

--- a/assets/targets/injection/header/index.scss
+++ b/assets/targets/injection/header/index.scss
@@ -697,6 +697,8 @@
       @include rem(font-size, 9px);
       @include rem(padding, 0 10px);
       @include rem(width, 40px);
+      box-sizing: content-box;
+      color: $navy;
       cursor: pointer;
       display: table-cell;
       font-weight: $regular;
@@ -705,13 +707,6 @@
       text-transform: uppercase;
       transition: background-color 0.3s, color 0.3s, transform 0.3s;
       vertical-align: top;
-
-      color: $navy;
-
-      box-sizing: content-box;
-      /* autoprefixer: off */
-      -moz-box-sizing: content-box;
-      /* autoprefixer: on */
 
       svg {
         @include rem(height, 20px);
@@ -774,16 +769,12 @@
     @include rem(padding, 0 10px);
     @include rem(width, 40px);
     border-left: 1px solid darken($lightgray, 10%);
+    box-sizing: content-box;
     font-weight: $regular;
     line-height: 1;
     text-align: center;
     text-transform: uppercase;
     transition: background-color 0.3s, color 0.3s, transform 0.3s;
-
-    box-sizing: content-box;
-    /* autoprefixer: off */
-    -moz-box-sizing: content-box;
-    /* autoprefixer: on */
 
     svg {
       @include rem(height, 20px);

--- a/assets/targets/injection/patterns.scss
+++ b/assets/targets/injection/patterns.scss
@@ -41,11 +41,6 @@
 }
 
 %normalise {
-  /* autoprefixer: off */
-  -moz-box-sizing: border-box;
-  -ms-box-sizing: border-box;
-  -webkit-box-sizing: border-box;
-  /* autoprefixer: on */
   box-sizing: border-box;
   margin: 0;
   padding: 0;


### PR DESCRIPTION
Let autoprefixer decide which ones to add at build time.

- Prefixes for non-standard properties (e.g. column break, font smoothing) and pseudo-selectors (e.g. placeholder) have not been touched.
- Old gradient declarations have been removed except for the IE9 `filter` fallback.
- The implementation of the `hue-rotation` animation on `h1.highlight` has been simplified: the background doesn't need to be clipped to the text because the `hue-rotate` filter works on the text itself.