### PR TITLE
Fix max-width of news index when wrapped inside a section

### DIFF
--- a/assets/targets/components/news/_list.scss
+++ b/assets/targets/components/news/_list.scss
@@ -60,6 +60,8 @@
 }
 
 .uomcontent .news-index {
+  max-width: none !important;
+
   article {
     @extend %clearfix;
     @include padding-leader(2);

--- a/assets/targets/components/news/_list.scss
+++ b/assets/targets/components/news/_list.scss
@@ -60,8 +60,6 @@
 }
 
 .uomcontent .news-index {
-  max-width: none !important;
-
   article {
     @extend %clearfix;
     @include padding-leader(2);
@@ -259,6 +257,11 @@
     }
   }
 }
+
+.uomcontent [role="main"] section .news-index {
+  max-width: none;
+}
+
 
 .ie8 .uomcontent {
   .news-hero {


### PR DESCRIPTION
Cancel out the max-width from `section div`, which gets applied when
the news index is wrapped inside a section.