### PR TITLE
Add 21:9 aspect for video embeds

### DIFF
--- a/assets/targets/components/media/05-youtube.slim
+++ b/assets/targets/components/media/05-youtube.slim
@@ -1,2 +1,5 @@
 section.video
 	iframe width="420" height="315" src="//www.youtube.com/embed/nlF7qp5GNPI" frameborder="0" allowfullscreen="true" title="video player"
+
+section.video-21-9
+  iframe allowfullscreen="true" frameborder="0" height="315" src="//www.youtube.com/embed/0XuNcBK6aDs" width="420" title="video player"

--- a/assets/targets/components/media/05-youtube.slim
+++ b/assets/targets/components/media/05-youtube.slim
@@ -1,5 +1,5 @@
 section.video
 	iframe width="420" height="315" src="//www.youtube.com/embed/nlF7qp5GNPI" frameborder="0" allowfullscreen="true" title="video player"
 
-section.video-21-9
+section.video.video--21-9
   iframe allowfullscreen="true" frameborder="0" height="315" src="//www.youtube.com/embed/0XuNcBK6aDs" width="420" title="video player"

--- a/assets/targets/components/media/_videos.scss
+++ b/assets/targets/components/media/_videos.scss
@@ -1,5 +1,6 @@
 .uomcontent [role="main"] {
-  .video {
+  // Default 16:9
+  %video {
     height: 0;
     margin-left: auto;
     max-width: 1099px;
@@ -66,19 +67,18 @@
     }
   }
 
-  .video-4-3 {
-    @extend .video;
-    padding-bottom: 75%;
+  .video {
+    @extend %video;
+  }
 
-    @include breakpoint(desktop) {
-      padding-bottom: 33%;
-    }
+  // 21:9
+  .video-21-9 {
+    @extend %video;
+    padding-bottom: 42.5%;
 
-    [data-ytid] {
-      @include breakpoint(desktop) {
-        margin: 0 28%;
-        width: 44%;
-      }
+    @include breakpoint(wide) {
+      max-width: 100%;
+      padding-bottom: 29.75%;
     }
   }
 

--- a/assets/targets/components/media/_videos.scss
+++ b/assets/targets/components/media/_videos.scss
@@ -1,6 +1,6 @@
 .uomcontent [role="main"] {
   // Default 16:9
-  %video {
+  .video {
     height: 0;
     margin-left: auto;
     max-width: 1099px;
@@ -67,12 +67,8 @@
     }
   }
 
-  .video {
-    @extend %video;
-  }
-
   // 21:9
-  .video-21-9 {
+  .video.video--21-9 {
     @extend %video;
     padding-bottom: 42.5%;
 

--- a/assets/targets/components/media/index.scss
+++ b/assets/targets/components/media/index.scss
@@ -1,3 +1,3 @@
 @import 'images';
-@import 'yt';
+@import 'videos';
 @import 'soundcloud';


### PR DESCRIPTION
Also:
* Remove 4:3 (deprecated on youtube)
* Move main styling setup into placeholder to avoid over-duplication of compiled styles

Fixes #620