### PR TITLE
Escape numeric id for smooth scroll

### DIFF
--- a/assets/targets/components/index.js
+++ b/assets/targets/components/index.js
@@ -4,6 +4,8 @@ require("../../shared/smoothscroll");
 require("../../shared/findup");
 require("../../shared/loadscript");
 
+window.cssesc = require("cssesc");
+
 // Also need one to find non-text nodes in a list of children
 
 // Simple sniff

--- a/assets/targets/components/inpage-navigation/index.js
+++ b/assets/targets/components/inpage-navigation/index.js
@@ -22,7 +22,7 @@ InpageNavigation.prototype.delegateScroll = function(e) {
     if (target) {
       if (target != '#' && target != '#sitemap') {
         e.preventDefault();
-        target = document.querySelector(target);
+        target = document.querySelector('#' + cssesc(target.substr(1), { 'isIdentifier': true }));
 
         var tabbed = findUp(e.target, 'data-tabbed');
         if (tabbed && !e.target.parentNode.parentNode.classList.contains('jump-navigation')) {

--- a/assets/targets/components/tabs/01-full-width-navigation-tabs.slim
+++ b/assets/targets/components/tabs/01-full-width-navigation-tabs.slim
@@ -1,12 +1,12 @@
 div.tabbed-nav data-tabbed="" id="nav"
   .full-width
     nav role="tablist"
-      a href="#tab1" role="tab" Tab1
+      a href="#1tab" role="tab" Tab1
       a href="#tab2" role="tab" data-current="" Tab2
       a href="#tab3" role="tab"
         span.small data-icon="chat" Contact
       a href="/" role="tab" External
-  .tab role="tabpanel" id="tab1"
+  .tab role="tabpanel" id="1tab"
     section.lead
       p Lorem ipsum dolor sit amet, dissentiet definitiones vix te, libris quaeque repudiandae mei cu, at duo indoctum instructior delicatissimi. Et sed stet partem, enim altera eam ei. Pro erat zril omittam ea. Eu choro aeterno vix, nonumy aliquip mei ne, cum putant perpetua periculis at.
   .tab role="tabpanel" id="tab2"

--- a/assets/targets/components/tabs/_tabs.scss
+++ b/assets/targets/components/tabs/_tabs.scss
@@ -109,7 +109,7 @@
       }
     }
 
-    /* wrapper added dynamically around nav element when tabs overflow */
+    // wrapper added dynamically around nav element when tabs overflow
     .tabbed-nav__inner {
       @include rem(padding-bottom, 15px);
       position: relative;
@@ -120,15 +120,15 @@
       z-index: 5;
     }
 
-    /* show scrollbar when focused */
+    // show scrollbar when focused
     .ps-focus .ps-scrollbar-x-rail {
       opacity: 1;
     }
 
-    /* left/right arrows when screen size is too small to fit all the tabs */
+    // left/right arrows when screen size is too small to fit all the tabs
     .tab-arrow {
       @include rem(font-size, 30px);
-      @include rem(padding, 0 20px 5px); /* bottom padding aligns arrows with tab labels */
+      @include rem(padding, 0 20px 5px); // bottom padding aligns arrows with tab labels
       background: $darkblue;
       color: $white;
       cursor: pointer;
@@ -143,7 +143,7 @@
         cursor: default;
         opacity: .5;
       }
-      
+
       &:focus {
         outline: 1px dotted $white;
       }
@@ -159,7 +159,7 @@
       right: 0;
     }
 
-    /* show the arrows when the tabs overflow */
+    // show the arrows when the tabs overflow
     .overflow .tab-arrow {
       display: inline-block;
     }

--- a/assets/targets/components/tabs/index.js
+++ b/assets/targets/components/tabs/index.js
@@ -83,7 +83,7 @@ Tabs.prototype.getInitialTab = function() {
     }
 
     // No match found; check for a matching inner tab (i.e. sidebar tabs, not in-page tabs)
-    var innerPanel = this.el.querySelector(window.location.hash + '.inner-nav-page');
+    var innerPanel = this.el.querySelector(cssesc(window.location.hash.substr(1), { 'isIdentifier': true }) + '.inner-nav-page');
     if (innerPanel) {
       // Inner-tab panel matches hash; find its parent panel's tab and return it
       var panel = findUp(innerPanel, 'tab');
@@ -333,7 +333,7 @@ Tabs.prototype.getIndex = function(target) {
 Tabs.prototype.move = function(target, smooth) {
   var current, panels, max, i;
 
-  this.movetab(this.getIndex(target));
+  this.movetabpanel(this.getIndex(target));
   this.scrollToTab(target, smooth);
 
   if (this.props.panels.length === 1) {
@@ -341,7 +341,7 @@ Tabs.prototype.move = function(target, smooth) {
     this.showPanel(current);
 
   } else {
-    current = this.el.querySelector(target.getAttribute('href'));
+    current = this.el.querySelector(cssesc(target.getAttribute('href').substr(1), { 'isIdentifier': true }));
 
     for (panels=this.el.querySelectorAll('[role="tabpanel"]'), max=panels.length, i=0; i < max; i++) {
       if (target.getAttribute('href') === '#'+panels[i].id) {
@@ -417,7 +417,7 @@ Tabs.prototype.animateTabsScroll = function(curr, start, change, duration, incre
 Tabs.prototype.moveindex = function(index) {
   var panels, max, i;
 
-  this.movetab(index);
+  this.movetabpanel(index);
 
   for (panels=this.el.querySelectorAll('[role="tabpanel"]'), max=panels.length, i=0; i < max; i++) {
     if (index === i) {
@@ -428,7 +428,7 @@ Tabs.prototype.moveindex = function(index) {
   }
 };
 
-Tabs.prototype.movetab = function(index) {
+Tabs.prototype.movetabpanel = function(index) {
   var max, i, opts, panels, current;
 
   for (max=this.props.tabs.length, i=0; i < max; i++) {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "autoprefixer-loader": "~2.0.0",
     "babel-core": "~5.8.3",
     "babel-loader": "~5.3.2",
+    "cssesc": "~0.1.0",
     "css-loader": "~0.9.1",
     "dotenv": "~1.1.0",
     "express": "~4.12.1",


### PR DESCRIPTION
Queryselector can only match an ID that starts with a number *if the string is escaped*.

eg. using `<h2 id="2012">Photos from 2012</h2>` as an anchor to the jump nav will cause a DOM Exception 12, originating from the queryselector call.

This PR introduces an external dependency, `cssesc`, to escape the ID string.

Ref: https://mathiasbynens.be/notes/css-escapes