### PR TITLE
Removed link in example text that no longer works

### DIFF
--- a/assets/targets/components/events/05-single-date-event-page-mixed-markup.slim
+++ b/assets/targets/components/events/05-single-date-event-page-mixed-markup.slim
@@ -29,7 +29,7 @@
 
     p This template <strong>Event block listing (local assets)</strong> is available if you wish to create local calendar events for your site.&nbsp;
 
-    p If you wish to promote your event to a wider audience you should post on <a href="events.unimelb.edu.au">events.unimelb.edu.au</a> and use the feed as described on the <a href="http://cms.unimelb.edu.au/controlled-environment/events">events.unimelb examples</a>.
+    p If you wish to promote your event to a wider audience you should post on <a href="events.unimelb.edu.au">events.unimelb.edu.au</a> and use the feed as described on the events.unimelb examples.
 
     p This event listing is using an <a href="http://manuals.matrix.squizsuite.net/calendar/chapters/upcoming-events-list">upcoming events list </a>&nbsp;and is set to show:&nbsp;
 


### PR DESCRIPTION
Broken link had been reported. Given it's just example text, I've removed the link entirely.