### PR TITLE
Add typed ol

### DIFF
--- a/assets/targets/components/base/04-02-complex-lists.slim
+++ b/assets/targets/components/base/04-02-complex-lists.slim
@@ -11,7 +11,7 @@ ul
     ' Ordered list, inner
     ol
       li Qui impetus tibique
-      li persequeris in vis.
+      li.no-li No bullet point, overriden
 ol
   li Qui impetus tibique
   li
@@ -22,6 +22,41 @@ ol
         ' Ordered list, inner-inner
         ol
           li Qui impetus tibique
+          li maluisset ne, omnes
+          li persequeris in vis.
+      li
+        ' Ordered list, inner-inner, type="a"
+        ol type="a"
+          li Qui impetus tibique
+          li maluisset ne, omnes
+          li persequeris in vis.
+          li
+            ' Ordered list, inner-inner-inner, type="i"
+            ol type="i"
+              li Qui impetus tibique
+              li maluisset ne, omnes
+              li
+                ' Ordered list, inner-inner-inner-inner, type="a"
+                ol type="a"
+                  li Qui impetus tibique
+                  li maluisset ne, omnes
+                  li persequeris in vis.
+          li
+            ' Ordered list, inner-inner-inner, type="d"
+            ol type="d"
+              li Qui impetus tibique
+              li maluisset ne, omnes
+              li persequeris in vis.
+      li
+        ' Ordered list, inner-inner, type="i"
+        ol type="i"
+          li Qui impetus tibique
+          li.no-li No bullet point, overriden
+          li persequeris in vis.
+      li
+        ' Unordered list, inner-inner
+        ul
+          li.no-li No bullet point, overriden
           li maluisset ne, omnes
           li persequeris in vis.
       li persequeris in vis.

--- a/assets/targets/components/base/_typography.scss
+++ b/assets/targets/components/base/_typography.scss
@@ -223,6 +223,42 @@
   ol {
     @include rem(padding-left, 30px);
 
+    &[type="a"] li {
+      list-style-type: lower-alpha;
+
+      ol[type="d"] li {
+        list-style-type: decimal;
+      }
+
+      ol[type="i"] li {
+        list-style-type: lower-roman;
+      }
+    }
+
+    &[type="i"] li {
+      list-style-type: lower-roman;
+
+      ol[type="a"] li {
+        list-style-type: lower-alpha;
+      }
+
+      ol[type="d"] li {
+        list-style-type: decimal;
+      }
+    }
+
+    &[type="d"] li {
+      list-style-type: decimal;
+
+      ol[type="a"] li {
+        list-style-type: lower-alpha;
+      }
+
+      ol[type="i"] li {
+        list-style-type: lower-roman;
+      }
+    }
+
     &.steps {
       @include rem(max-width, $w-mid);
       counter-reset: steps;


### PR DESCRIPTION
Also:
* expand documentation

Note- the style is only resettable to 3 levels ie.

```
<ul type="d">
  <li>
    <ul type="a">
      <li>
        <ul type="i">
```

`1. a) i.`

(The above combination of nested list-type is set by default for all `ol`, so you won't need to add `type` if this style is suitable) 

Fix #641
