### PR TITLE
Update event example to accomodate multi-day events

### DIFF
--- a/assets/targets/components/events/01-event-listing.slim
+++ b/assets/targets/components/events/01-event-listing.slim
@@ -8,6 +8,7 @@ ul.event-listing
     ul
       li
         a href=''
+          strong.time 2:00pm – 5:00pm
           h3 Lorem ipsum dolor
           p Nam vestibulum porttitor ipsum tincidunt semper. Suspendisse id euismod orci, quis egestas nulla. Donec sit amet auctor justo. Nam a turpis ac diam fringilla ullamcorper ac quis quam.
         .tags
@@ -19,6 +20,7 @@ ul.event-listing
               span data-icon="tag" Aenean sed feugiat nulla
       li
         a href=''
+          strong.time 12 September - 23 September
           h3 Duis ultricies eget diam laoreet molestie
           p Nulla interdum magna a euismod laoreet. Pellentesque convallis posuere placerat.  Tempor dictum nisi vitae bibendum. Praesent nec quam tellus. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
         .tags

--- a/assets/targets/components/events/02-event-listing-with-presenters.slim
+++ b/assets/targets/components/events/02-event-listing-with-presenters.slim
@@ -25,7 +25,7 @@ ul.event-listing
 
       li
         a.col href=""
-          strong.time 5:00pm – 9:00pm
+          strong.time 12 September - 23 September
           h3 Duis ultricies eget diam laoreet molestie
           p There is no doubt that technology is a powerful agent of transformation, and will be an essential component of any attempt at reforming the way healthcare is delivered. Making care safer, more efficient, and economically sustainable is unlikely to...
           .tags


### PR DESCRIPTION
This PR provides an example multi-date event (e.g. exhibitions) example that seems to make sense. I can't think of any other way to display this sort of info in a chronological way. 