### PR TITLE
Use fixed height to mitigate IE flexbox implementation

### DIFF
--- a/assets/targets/components/listings/_block.scss
+++ b/assets/targets/components/listings/_block.scss
@@ -567,7 +567,7 @@
           border-bottom: 1px solid $lightergray;
           color: $highlight;
           display: block;
-          height: 20%;
+          height: 100%;
           position: relative;
           text-align: center;
           vertical-align: middle;
@@ -633,6 +633,7 @@
 
         @include breakpoint(600px) {
           .block-container {
+            @include rem(height, 440px); // IE flexbox implementation bug
             align-items: flex-start;
             display: flex;
             flex-direction: column;


### PR DESCRIPTION
Also: the block needs to have 100% height within its container. This doesn't seem to affect other browsers.

Fixes #649 