### PR TITLE
Fix lower/upper default ol types

### DIFF
--- a/assets/targets/components/base/03-03-ordered-list-uppercase-alpha.slim
+++ b/assets/targets/components/base/03-03-ordered-list-uppercase-alpha.slim
@@ -1,4 +1,0 @@
-ol type="A"
-  li Ordered list items
-  li Ordered list items
-  li Ordered list items

--- a/assets/targets/components/base/03-04-ordered-list-uppercase-roman-numerals.slim
+++ b/assets/targets/components/base/03-04-ordered-list-uppercase-roman-numerals.slim
@@ -1,4 +1,0 @@
-ol type="I"
-  li Ordered list items
-  li Ordered list items
-  li Ordered list items

--- a/assets/targets/components/base/04-02-complex-lists.slim
+++ b/assets/targets/components/base/04-02-complex-lists.slim
@@ -42,8 +42,8 @@ ol
                   li maluisset ne, omnes
                   li persequeris in vis.
           li
-            ' Ordered list, inner-inner-inner, type="d"
-            ol type="d"
+            ' Ordered list, inner-inner-inner, type="1"
+            ol type="1"
               li Qui impetus tibique
               li maluisset ne, omnes
               li persequeris in vis.

--- a/assets/targets/components/base/_typography.scss
+++ b/assets/targets/components/base/_typography.scss
@@ -223,108 +223,50 @@
     }
 
     @include inner-list-reset;
+
+    // Remove bottom padding for inner lists
+    ol,
+    ul {
+      padding-bottom: 0;
+    }
   }
 
   ol {
     @include rem(padding-left, 30px);
 
-    &[type="\a"] li {
+    &[type="a"] li {
       list-style-type: lower-alpha;
 
-      ol[type="\A"] li {
-        list-style-type: upper-alpha;
-      }
-
       ol[type="1"] li {
         list-style-type: decimal;
       }
 
-      ol[type="\i"] li {
+      ol[type="i"] li {
         list-style-type: lower-roman;
-      }
-
-      ol[type="\I"] li {
-        list-style-type: upper-roman;
       }
     }
 
-    &[type="\A"] li {
-      list-style-type: upper-alpha;
-
-      ol[type="\a"] li {
-        list-style-type: lower-alpha;
-      }
-
-      ol[type="1"] li {
-        list-style-type: decimal;
-      }
-
-      ol[type="\i"] li {
-        list-style-type: lower-roman;
-      }
-
-      ol[type="\I"] li {
-        list-style-type: upper-roman;
-      }
-    }
-
-    &[type="\i"] li {
+    &[type="i"] li {
       list-style-type: lower-roman;
 
-      ol[type="\a"] li {
+      ol[type="a"] li {
         list-style-type: lower-alpha;
-      }
-
-      ol[type="\A"] li {
-        list-style-type: upper-alpha;
       }
 
       ol[type="1"] li {
         list-style-type: decimal;
-      }
-
-      ol[type="\I"] li {
-        list-style-type: upper-roman;
-      }
-    }
-
-    &[type="\I"] li {
-      list-style-type: upper-roman;
-
-      ol[type="\a"] li {
-        list-style-type: lower-alpha;
-      }
-
-      ol[type="\A"] li {
-        list-style-type: upper-alpha;
-      }
-
-      ol[type="1"] li {
-        list-style-type: decimal;
-      }
-
-      ol[type="\i"] li {
-        list-style-type: lower-roman;
       }
     }
 
     &[type="1"] li {
       list-style-type: decimal;
 
-      ol[type="\a"] li {
+      ol[type="a"] li {
         list-style-type: lower-alpha;
       }
 
-      ol[type="\A"] li {
-        list-style-type: upper-alpha;
-      }
-
-      ol[type="\i"] li {
+      ol[type="i"] li {
         list-style-type: lower-roman;
-      }
-
-      ol[type="\I"] li {
-        list-style-type: upper-roman;
       }
     }
 

--- a/assets/targets/components/base/_typography.scss
+++ b/assets/targets/components/base/_typography.scss
@@ -228,39 +228,103 @@
   ol {
     @include rem(padding-left, 30px);
 
-    &[type="a"] li {
+    &[type="\a"] li {
       list-style-type: lower-alpha;
 
-      ol[type="d"] li {
+      ol[type="\A"] li {
+        list-style-type: upper-alpha;
+      }
+
+      ol[type="1"] li {
         list-style-type: decimal;
       }
 
-      ol[type="i"] li {
+      ol[type="\i"] li {
         list-style-type: lower-roman;
+      }
+
+      ol[type="\I"] li {
+        list-style-type: upper-roman;
       }
     }
 
-    &[type="i"] li {
+    &[type="\A"] li {
+      list-style-type: upper-alpha;
+
+      ol[type="\a"] li {
+        list-style-type: lower-alpha;
+      }
+
+      ol[type="1"] li {
+        list-style-type: decimal;
+      }
+
+      ol[type="\i"] li {
+        list-style-type: lower-roman;
+      }
+
+      ol[type="\I"] li {
+        list-style-type: upper-roman;
+      }
+    }
+
+    &[type="\i"] li {
       list-style-type: lower-roman;
 
-      ol[type="a"] li {
+      ol[type="\a"] li {
         list-style-type: lower-alpha;
       }
 
-      ol[type="d"] li {
+      ol[type="\A"] li {
+        list-style-type: upper-alpha;
+      }
+
+      ol[type="1"] li {
         list-style-type: decimal;
+      }
+
+      ol[type="\I"] li {
+        list-style-type: upper-roman;
       }
     }
 
-    &[type="d"] li {
-      list-style-type: decimal;
+    &[type="\I"] li {
+      list-style-type: upper-roman;
 
-      ol[type="a"] li {
+      ol[type="\a"] li {
         list-style-type: lower-alpha;
       }
 
-      ol[type="i"] li {
+      ol[type="\A"] li {
+        list-style-type: upper-alpha;
+      }
+
+      ol[type="1"] li {
+        list-style-type: decimal;
+      }
+
+      ol[type="\i"] li {
         list-style-type: lower-roman;
+      }
+    }
+
+    &[type="1"] li {
+      list-style-type: decimal;
+
+      ol[type="\a"] li {
+        list-style-type: lower-alpha;
+      }
+
+      ol[type="\A"] li {
+        list-style-type: upper-alpha;
+      }
+
+      ol[type="\i"] li {
+        list-style-type: lower-roman;
+      }
+
+      ol[type="\I"] li {
+        list-style-type: upper-roman;
       }
     }
 
@@ -402,6 +466,8 @@
     }
 
     ol {
+      counter-reset: section;
+      list-style-type: none;
       padding: 1em 0 0;
 
       li::before {


### PR DESCRIPTION
HTML ​is​ case sensitive, so `type="A"` is different to `type="a"`. But CSS is ​_not_​ case sensitive, so it can't differentiate those two selectors (the last declaration in source order overrides the first). 

There was an odd hack that allowed both upper- and lower- alpha, but it didn't work for roman so I'm going to leave the system with lower only for consistency. Note: this would all be fixed by *never* changing default `list-style-type` on bare/unclassed elements, ie. use BEM. Doc examples removed to avoid confusion.