### PR TITLE
Change search form name attr to q

### DIFF
--- a/assets/targets/injection/header/index.es6
+++ b/assets/targets/injection/header/index.es6
@@ -249,7 +249,7 @@ InjectHeader.prototype.renderSearchBox = function() {
   <fieldset>
     <div class="inline attached">
       <span class="fill">
-        <input aria-label="Search" aria-required="true" autocomplete="off" data-error="Please enter a keyword" name="query" id="header_q" placeholder="Search the University" type="search" />
+        <input aria-label="Search" aria-required="true" autocomplete="off" data-error="Please enter a keyword" name="q" id="header_q" placeholder="Search the University" type="search" />
       </span>
       <span>
         <button class="inline-button" type="submit">


### PR DESCRIPTION
We've been using `name="query"` for a long time, at least since the v2/3 rewrite, the GSA needs `name="q"`.