### PR TITLE
Remove Firefox sniffing

### DIFF
--- a/assets/shared/smoothscroll.js
+++ b/assets/shared/smoothscroll.js
@@ -1,18 +1,6 @@
 (function(root) {
   "use strict";
 
-  if (typeof Math.easeInOutQuad === "undefined") {
-    Math.easeInOutQuad = function(curr, start, change, duration) {
-      curr /= duration/2;
-      if (curr < 1) {
-        return change/2 * curr * curr + start;
-      } else {
-        curr--;
-        return -change/2 * (curr*(curr-2) - 1) + start;
-      }
-    };
-  }
-
   /**
    * Visually scroll viewport to inner page element (to) using custom easing,
    * expose function to global scope
@@ -21,15 +9,10 @@
    */
   if (typeof window.smoothScrollTo === "undefined") {
     window.smoothScrollTo = function(to, cb) {
-      var element = document.body,
-          headerElem = document.querySelector('.page-header');
-
-      if (/(Firefox)/g.test(navigator.userAgent) || /(Trident)/g.test(navigator.userAgent)) {
-        element = document.querySelector('html');
-      }
+      var headerElem = document.querySelector('.page-header');
 
       // Incr and dur numbers are completely arbitrary, but seem good
-      var start     = element.scrollTop,
+      var start     = window.scrollY || window.pageYOffset,
           curr      = 0,
           change    = to.getBoundingClientRect().top,
           offset    = 0,
@@ -42,30 +25,45 @@
         var headerPosition = window.getComputedStyle ? window.getComputedStyle(headerElem).getPropertyValue('position') : 'fixed';
         if (headerPosition === 'fixed' || headerPosition === 'absolute') {
           offset = 40;
+          change -= offset;
         }
       }
 
-      // Deduct offset
-      change -= offset;
+      // Start scrolling
+      if (change !== 0) {
+        animateScroll();
+      }
 
-      var animateScroll = function() {
+      function animateScroll() {
         curr += increment;
-        element.scrollTop = Math.easeInOutQuad(curr, start, change, duration);
+        window.scrollTo(0, Math.easeInOutQuad(curr, start, change, duration));
+
         if (curr < duration) {
           setTimeout(animateScroll, increment);
         } else {
           // Fix scrolling inaccuracy (always 1 or 2 pixels off without it)
-          element.scrollTop += to.getBoundingClientRect().top - offset;
+          window.scrollTo(0, start + change);
 
           // Invoke callback if any
           if (cb) {
             cb();
           }
         }
-      };
+      }
+    };
+  }
 
-      if (change !== 0) {
-        animateScroll();
+  /**
+   * Easing function used for smooth scroll.
+   */
+  if (typeof Math.easeInOutQuad === "undefined") {
+    Math.easeInOutQuad = function(curr, start, change, duration) {
+      curr /= duration/2;
+      if (curr < 1) {
+        return change/2 * curr * curr + start;
+      } else {
+        curr--;
+        return -change/2 * (curr*(curr-2) - 1) + start;
       }
     };
   }

--- a/assets/targets/injection/header/index.es6
+++ b/assets/targets/injection/header/index.es6
@@ -294,12 +294,7 @@ InjectHeader.prototype.reorderStructure = function() {
 };
 
 InjectHeader.prototype.handleScroll = function(e) {
-  var outer = document.body;
-  if (/(Firefox)/g.test(navigator.userAgent) || /(Trident)/g.test(navigator.userAgent)) {
-    outer = document.querySelector('html');
-  }
-
-  this.props.header.classList.toggle('fixed', outer.scrollTop > 40);
+  this.props.header.classList.toggle('fixed', (window.scrollY || window.pageYOffset) > 40);
 };
 
 module.exports = InjectHeader;


### PR DESCRIPTION
Firefox sniffing was previously required when scrolling the page programmatically or retriving the page's scroll position (via `[documentElement|body].scrollTop`). Now that IE8 support is not required, we can use `window.scrollTo()` and `window.[scrollY|pageYOffset]`.

This PR improves a couple of other things; see first two commits for more info. I've also ignored one instance of Firefox sniffing, as it has already been removed in #607.