### PR TITLE
Fix toggling of JS classes on document root

### DIFF
--- a/assets/targets/injection/index.js
+++ b/assets/targets/injection/index.js
@@ -7,6 +7,10 @@ require("./tealium");
 if (typeof window.MSIE_version === "undefined")
   window.MSIE_version = /MSIE\s(\d{1,2})/g.exec(navigator.userAgent) === null ? 100 : /MSIE\s(\d{1,2})/g.exec(navigator.userAgent)[1];
 
+// Toggle JS classes on document root
+document.documentElement.classList.remove('no-js');
+document.documentElement.classList.add('js');
+
 window.UOMbindIcons = function() {
   "use strict";
 
@@ -33,10 +37,6 @@ window.UOMbindIcons = function() {
 
 window.UOMloadInjection = function() {
   "use strict";
-
-  // Toggle JS classes on document root
-  document.documentElement.classList.remove('no-js');
-  document.documentElement.classList.add('js');
 
   var assethostFooter, assethostHeader, Header, Nav, Footer, Icons, Accouncement;
   assethostHeader = assethostFooter = process.env.CDNURL;

--- a/assets/targets/injection/index.js
+++ b/assets/targets/injection/index.js
@@ -34,6 +34,10 @@ window.UOMbindIcons = function() {
 window.UOMloadInjection = function() {
   "use strict";
 
+  // Toggle JS classes on document root
+  document.documentElement.classList.remove('no-js');
+  document.documentElement.classList.add('js');
+
   var assethostFooter, assethostHeader, Header, Nav, Footer, Icons, Accouncement;
   assethostHeader = assethostFooter = process.env.CDNURL;
   // assethostHeader += '/injection/header';

--- a/views/pages/getting-started.slim.md
+++ b/views/pages/getting-started.slim.md
@@ -34,7 +34,7 @@ pre: code.html
   ==convert_tags
     erb:
       <!DOCTYPE html>
-      <html lang="en">
+      <html lang="en" class="no-js">
       <head>
         <meta charset="utf-8" />
         <meta content="width=device-width, initial-scale=1.0" name="viewport" />


### PR DESCRIPTION
Replace `no-js` class with `js` on `html` element when the page loads. Also, use `no-js` class in markup example on [Getting started](https://web.unimelb.edu.au/getting-started/) page.