### PR TITLE
Fix broken nav on IE9

### DIFF
--- a/assets/targets/components/gallery/_gallery.scss
+++ b/assets/targets/components/gallery/_gallery.scss
@@ -70,7 +70,7 @@
 
       span {
         background-color: rgba($black, .6);
-        background-image: linear-gradient(left top, rgba(0, 150, 255, .3) 0%, rgba(255, 0, 126, .3) 100%);
+        background-image: linear-gradient(to right bottom, rgba(0, 150, 255, .3) 0%, rgba(255, 0, 126, .3) 100%);
         bottom: 0;
         cursor: pointer;
         display: block;

--- a/assets/webpack.config.js
+++ b/assets/webpack.config.js
@@ -5,6 +5,7 @@ var WEBPACK_URL = "http://"+process.env.WEB_SERVER_HOST+":"+process.env.WEBPACK_
 var fs = require('fs');
 var path = require('path');
 var webpack = require('webpack');
+var autoprefixer = require('autoprefixer');
 
 // Webpack plugins
 var ExtractTextPlugin = require("extract-text-webpack-plugin");
@@ -73,11 +74,11 @@ module.exports = {
       },
       {
         test: /\.scss$/,
-        loader: ExtractTextPlugin.extract("style-loader", "css-loader?-minimize!autoprefixer-loader!sass-loader")
+        loader: ExtractTextPlugin.extract("style-loader", "css-loader?-minimize!postcss-loader!sass-loader")
       },
       {
         test: /\.css$/,
-        loader: ExtractTextPlugin.extract("style-loader", "css-loader?-minimize!autoprefixer-loader")
+        loader: ExtractTextPlugin.extract("style-loader", "css-loader?-minimize!postcss-loader")
       },
       {
         test: /(isotope-layout|imagesloaded)/,
@@ -88,7 +89,12 @@ module.exports = {
   jshint: {
     eqnull: true,
     failOnHint: false
-  }
+  },
+  postcss: [
+    autoprefixer({
+      browsers: ['> 1%', 'last 2 versions', 'Firefox ESR']
+    })
+  ]
 };
 
 function isDirectory(dir) {

--- a/assets/webpack.config.js
+++ b/assets/webpack.config.js
@@ -92,7 +92,7 @@ module.exports = {
   },
   postcss: [
     autoprefixer({
-      browsers: ['> 1%', 'last 2 versions', 'Firefox ESR']
+      browsers: ['> 1%', 'last 2 versions', 'Firefox ESR', 'ie >= 9']
     })
   ]
 };

--- a/assets/webpack.config.js
+++ b/assets/webpack.config.js
@@ -92,7 +92,7 @@ module.exports = {
   },
   postcss: [
     autoprefixer({
-      browsers: ['> 1%', 'last 2 versions', 'Firefox ESR', 'ie >= 9']
+      browsers: ['> 1% in AU', 'last 2 versions', 'Firefox ESR', 'ie >= 9']
     })
   ]
 };

--- a/package.json
+++ b/package.json
@@ -22,11 +22,11 @@
     "build": "node_modules/.bin/webpack --config ./assets/webpack.config.js -p"
   },
   "devDependencies": {
-    "autoprefixer-loader": "~2.0.0",
+    "autoprefixer": "^6.4.0",
     "babel-core": "~5.8.3",
     "babel-loader": "~5.3.2",
-    "cssesc": "~0.1.0",
     "css-loader": "~0.9.1",
+    "cssesc": "~0.1.0",
     "dotenv": "~2.0.0",
     "express": "~4.12.1",
     "extract-text-webpack-plugin": "~0.3.8",
@@ -37,6 +37,7 @@
     "jshint": "~2.6.3",
     "jshint-loader": "~0.8.3",
     "node-sass": "~3.3.3",
+    "postcss-loader": "^0.9.1",
     "sass-loader": "~3.0.0",
     "style-loader": "~0.8.3",
     "webpack": "^1.13.1",


### PR DESCRIPTION
Autoprefixer stopped prefixing CSS transforms with `-ms` because IE9 must have dropped below 1% global market share.

This PR restores support for IE9 by overriding the default autoprefixer configuration. It also replaces `autoprefixer-loader` with `postcss-loader` and `autoprefixer`, as the former is deprecated.