### PR TITLE
Rename semantic aside element to div class=aside

### DIFF
--- a/assets/targets/components/_print.scss
+++ b/assets/targets/components/_print.scss
@@ -311,7 +311,7 @@ $white: #ffffff;
         white-space: pre-wrap;
       }
 
-      .filtered-listing-section aside {
+      .filtered-listing-section .aside {
         margin: 0;
         padding-bottom: 0;
         width: 100%;

--- a/assets/targets/components/base/02-typography-guidelines-no-source.slim
+++ b/assets/targets/components/base/02-typography-guidelines-no-source.slim
@@ -1,5 +1,5 @@
 .hold
-  aside
+  .aside
     dl
       dt Large headlines
       dd Only used on the hero. The background image must ensure readibility of the headline.
@@ -11,7 +11,7 @@
       span a b c d e f g h i j k l m n o p q r s t u v w x y z
       span 1 2 3 4 5 6 7 8 9 0 ! @ # $ % ^ & * ( )
 
-  aside
+  .aside
     dl
       dt Body text
       dd Used for standard copy text.
@@ -22,7 +22,7 @@
       span a b c d e f g h i j k l m n o p q r s t u v w x y z
       span 1 2 3 4 5 6 7 8 9 0 ! @ # $ % ^ & * ( )
 
-  aside
+  .aside
     dl
       dt Special highlighting
       dd Image captions, quoting etc.
@@ -35,7 +35,7 @@
         span a b c d e f g h i j k l m n o p q r s t u v w x y z
         span 1 2 3 4 5 6 7 8 9 0 ! @ # $ % ^ & * ( )
 
-  aside
+  .aside
     dl
       dt General headlines
       dd Font used for all standard headlines within a text.
@@ -46,7 +46,7 @@
       span a b c d e f g h i j k l m n o p q r s t u v w x y z
       span 1 2 3 4 5 6 7 8 9 0 ! @ # $ % ^ & * ( )
 
-  aside
+  .aside
     dl
       dt Article headlines
       dd Only used as the headline for a single article.

--- a/assets/targets/components/base/_courses.scss
+++ b/assets/targets/components/base/_courses.scss
@@ -300,7 +300,7 @@
   }
 
   .course-section {
-    aside {
+    .aside {
       float: left;
       margin: 0;
       max-width: 28%;

--- a/assets/targets/components/base/_layout.scss
+++ b/assets/targets/components/base/_layout.scss
@@ -47,7 +47,7 @@ body {
     @include padding-trailer(2);
   }
 
-  aside {
+  .aside {
     @include adjust-font-size-to(14px);
     color: $darkgray;
     float: right;
@@ -242,7 +242,7 @@ body {
     font-weight: $light;
   }
 
-  aside {
+  .aside {
     clear: both;
     float: left;
     width: 100%;
@@ -272,7 +272,7 @@ body {
     @include rem(max-width, $w-mid);
     margin: 0 auto;
 
-    aside {
+    .aside {
       @include rem(padding-bottom, 15px);
       @include rem(padding-top, 5px);
       vertical-align: top;

--- a/assets/targets/components/base/_timetable.scss
+++ b/assets/targets/components/base/_timetable.scss
@@ -42,7 +42,7 @@
     }
   }
 
-  aside {
+  .aside {
     background-color: $paleblue;
 
     h2 {

--- a/assets/targets/components/events/03-multi-date-event-page.slim
+++ b/assets/targets/components/events/03-multi-date-event-page.slim
@@ -1,8 +1,8 @@
 .detail
   .upper
     h1 My Event's Title
-		
-    aside
+
+    .aside
       .when.range
         time datetime='2014-09-01'
           | Monday
@@ -15,7 +15,7 @@
     img src='http://placeimg.com/1000/500' alt='Photo of my event'
 
   .lower
-    aside
+    .aside
       div
         p
           | 780 Elizabeth Street

--- a/assets/targets/components/events/04-single-date-event-page-with-presenters.slim
+++ b/assets/targets/components/events/04-single-date-event-page-with-presenters.slim
@@ -1,7 +1,7 @@
 .detail
   .upper
   	h1 My Event's Title
-    aside
+    .aside
       .when
         time datetime="2014-09-01"
           | Monday
@@ -13,7 +13,7 @@
     img src="http://placeimg.com/1000/500" alt="Photo of my event"
 
   .lower
-    aside
+    .aside
       div
         p
           | 780 Elizabeth Street

--- a/assets/targets/components/events/05-single-date-event-page-mixed-markup.slim
+++ b/assets/targets/components/events/05-single-date-event-page-mixed-markup.slim
@@ -1,8 +1,8 @@
 .detail
   .upper
     h1 Create the main events listing page
-    
-    aside
+
+    .aside
       .when
         time datetime="2014-09-01"
           | Monday
@@ -12,7 +12,7 @@
     img src="http://placeimg.com/1000/500" alt="Photo of my event"
 
   .lower
-    aside
+    .aside
       div
         p
           ' 780 Elizabeth Street

--- a/assets/targets/components/events/_events-detail.scss
+++ b/assets/targets/components/events/_events-detail.scss
@@ -3,7 +3,7 @@
   @include padding-leader(1);
   @include padding-trailer(2);
 
-  aside {
+  .aside {
     @include padding-leader(2);
     @include padding-trailer(2);
     @include rem(padding-left, 30px);
@@ -129,7 +129,7 @@
       @include rem(margin-left, 300px);
     }
 
-    aside {
+    .aside {
       padding-top: 0;
 
       @include breakpoint(desktop) {
@@ -173,7 +173,7 @@
     @include breakpoint(desktop) {
       @include rem(margin-left, 300px);
 
-      aside {
+      .aside {
         @include rem(margin-left, -300px);
 
         div {
@@ -224,7 +224,7 @@
       }
     }
 
-    aside {
+    .aside {
       padding-top: 0;
 
       [data-icon] .icon-over {
@@ -235,7 +235,7 @@
       }
     }
 
-    aside p {
+    .aside p {
       margin-left: auto;
     }
 

--- a/assets/targets/components/filtered-listings/04-listing.slim
+++ b/assets/targets/components/filtered-listings/04-listing.slim
@@ -1,6 +1,6 @@
 hr.spacer
 .filtered-listing-section.clearfix data-section="section-1"
-  aside
+  .aside
     h2 Section heading 1
     p Lorem ipsum dolor sit amet, vis te saepe nominavi appetere, ceteros lucilius te usu, no nam tota partiendo
   .bside
@@ -64,7 +64,7 @@ hr.spacer
 
 hr.spacer
 .filtered-listing-section.clearfix data-section="section-2"
-  aside
+  .aside
     h2 Different Section
     p Ex mei noluisse percipit, ea unum ludus invenire pri. Ei duo aliquid eleifend, errem qualisque at pro. Qui et elit delicatissimi, periculis elaboraret referrentur eam id, graece tractatos ut est. Aperiri delenit sed ei, pro simul principes
   .bside
@@ -100,7 +100,7 @@ hr.spacer
 
 hr.spacer
 .filtered-listing-section.clearfix data-section="section-3"
-  aside
+  .aside
     h2 Third Example Section
     p Ei nihil argumentum philosophia mel, commune accusata ius ex, homero scripserit an mea. Ne splendide deseruisse quo
   .bside

--- a/assets/targets/components/filtered-listings/_listing.scss
+++ b/assets/targets/components/filtered-listings/_listing.scss
@@ -7,7 +7,7 @@
     display: none;
   }
 
-  aside {
+  .aside {
     @include padding-trailer(2);
     float: none;
     margin: 0 3%;

--- a/assets/targets/components/news/04-news-single.slim
+++ b/assets/targets/components/news/04-news-single.slim
@@ -13,7 +13,7 @@ article.news
     p Professor Flannery was named Australian of the Year in 2007 for his work on population levels and carbon emissions and was also Chairman of the Copenhagen Climate Council, an international climate change awareness group. He was the Chief Commissioner of the Climate Commission before it was dismantled in 2013 and subsequently launched the Climate Council to ensure the continued provision of independent information on the science of climate change to the Australian public.
     p The Melbourne Sustainable Society Institute is dedicated to supporting research, projects and conversations about sustainability, as well as investigating the human and environmental challenges created by climate change.
 
-  aside
+  .aside
     div
       time datetime="2014-09-22" 22 September 2014
     div

--- a/assets/targets/components/news/05-news-single-with-image.slim
+++ b/assets/targets/components/news/05-news-single-with-image.slim
@@ -33,7 +33,7 @@ article.news
     p “We’re delighted to partner with Westpac to offer students an opportunity to become truly global citizens. We are now well and truly in the midst of the Asian Century, and we’re proud to join Westpac to help students become some of the nation’s most Asia-literate graduates. The hands-on experiences offered by the Asian Exchange scholarships will be invaluable for our promising students as they become tomorrow’s leaders,” said Dr Michael Spence, Vice-Chancellor of The University of Sydney.
     p Scholarship applications are now open at The University of Melbourne and the University of Sydney.
 
-  aside
+  .aside
     div
       time datetime="2014-09-22" 22 September 2014
     div

--- a/assets/targets/components/news/06-news-single-with-video.slim
+++ b/assets/targets/components/news/06-news-single-with-video.slim
@@ -7,7 +7,7 @@ article.news
     p Mr Reece thinks the debate is divisive and he has seen no evidence that the burqa is a security risk in Australia.
     p Nicholas Reece is a Public Policy Fellow at the Centre for Public Policy at the University of Melbourne. He was speaking on Sky News.
 
-  aside
+  .aside
     div
       time datetime="2014-09-22" 22 September 2014
     div

--- a/assets/targets/components/news/_article.scss
+++ b/assets/targets/components/news/_article.scss
@@ -23,7 +23,7 @@
     @include rem(padding-bottom, 15px);
   }
 
-  aside {
+  .aside {
     @include rem(padding-top, 15px);
 
     div {
@@ -111,7 +111,7 @@
         @include rem(margin-left, 20px);
       }
     }
-    aside {
+    .aside {
       display: inline-block;
       float: none;
       width: 29%;
@@ -122,7 +122,7 @@
     .article {
       width: 75%;
     }
-    aside {
+    .aside {
       width: 24%;
     }
 

--- a/assets/targets/components/tabs/02-sidebar-tabs.slim
+++ b/assets/targets/components/tabs/02-sidebar-tabs.slim
@@ -3,7 +3,7 @@ p If the sidebar is on the right-hand side of the page, use class <code>sidebar-
 p.alert-info <strong>Note:</strong> The sidebar layout should only ever be used as the <strong>main layout</strong> of a page, and not in the middle of a page like below.
 
 .layout-sidebar.sidebar-tabs
-  aside.layout-sidebar__side.box
+  .aside.layout-sidebar__side.box
     h2.subtitle Example
     p No modus albucius vis, ad duis fabellas per. Et vim viris habemus referrentur, in mei liber scaevola. Ponderum referrentur consectetuer sea eu, illud temporibus vim ei.
     ul.sidebar-tabs__list

--- a/assets/targets/components/tabs/_tabs.scss
+++ b/assets/targets/components/tabs/_tabs.scss
@@ -343,7 +343,7 @@
   .tabbed-course {
     @include tabbed-nav;
 
-    aside h2.subtitle {
+    .aside h2.subtitle {
       @include rem(padding-bottom, 5px);
     }
 

--- a/views/templates/course.slim
+++ b/views/templates/course.slim
@@ -59,7 +59,7 @@ div role="main"
 
     #course-structure.tab role="tabpanel"
       .layout-sidebar.sidebar-tabs
-        aside.layout-sidebar__side.box
+        .aside.layout-sidebar__side.box
           h2.subtitle Degree Structure
           p The Doctor of Veterinary Medicine is four years full-time, and is delivered at the Parkville campus (Years One and Two) and at the Werribee campus (Years Three and Four).
           p The Doctor of Veterinary Medicine (DVM) can be taken in three years via the ‘accelerated pathway’ if you have a Bachelor of Science degree from the University of Melbourne with a major in Animal Health and Disease (Veterinary Bioscience specialisation) and meet the entry requirements.
@@ -518,7 +518,7 @@ div role="main"
 
     #course-structure-2.tab role="tabpanel"
       .layout-sidebar.sidebar-tabs
-        aside.layout-sidebar__side.box
+        .aside.layout-sidebar__side.box
           h2.subtitle Second sidebar tabs test
           p The Doctor of Veterinary Medicine is&nbsp; four years full-time, and is delivered at the Parkville campus (Years One and Two) and at the Werribee campus (Years Three and Four).
           ul.sidebar-tabs__list role="tablist"
@@ -599,7 +599,7 @@ div role="main"
             p.center
               a.button-hero href="#apply" data-tab="6" Next : Apply now
 
-        aside.layout-sidebar__side.box
+        .aside.layout-sidebar__side.box
           p The fees for this degree are listed below, indicative for 2015.
           .pricing
             h2 400 point program

--- a/views/templates/event.slim
+++ b/views/templates/event.slim
@@ -5,14 +5,14 @@ div role="main"
     .upper
       h1 Title of the event goes right here
       h2 Event category
-      aside
+      .aside
         div class="when range"
           time datetime="2014-04-11" Friday <strong>11 Apr</strong> 2014
           time datetime="2014-05-03" Saturday <strong>03 May</strong> 2014
       img src="http://placeimg.com/1024/480/any"
 
     .lower
-      aside
+      .aside
         div
           p 780 Elizabeth Street<br />Melbourne VIC 3000
           a.button-small href=""

--- a/views/templates/fake-tab.slim
+++ b/views/templates/fake-tab.slim
@@ -27,7 +27,7 @@ div role="main"
 
     #requirements.tab data-current="" role="tabpanel"
       .layout-sidebar.sidebar-tabs
-        aside.layout-sidebar__side.box
+        .aside.layout-sidebar__side.box
           h2.subtitle 400 point program
           p 4 years full-time / part-time unavailable
 

--- a/views/templates/index.slim
+++ b/views/templates/index.slim
@@ -41,7 +41,7 @@ div role="main"
 
   hr.spacer
   .filtered-listing-section.clearfix data-section="website-sections"
-    aside
+    .aside
       h2 Website sections
       p Combined Layouts across more than one page addressing common sections of a website
     .bside
@@ -73,7 +73,7 @@ div role="main"
 
   hr.spacer
   .filtered-listing-section.clearfix data-section="news"
-    aside
+    .aside
       h2 News
       p Ways to display news
     .bside
@@ -93,7 +93,7 @@ div role="main"
 
   hr.spacer
   .filtered-listing-section.clearfix data-section="events"
-    aside
+    .aside
       h2 Events
       p Ways to display events
     .bside
@@ -117,7 +117,7 @@ div role="main"
 
   hr.spacer
   .filtered-listing-section.clearfix data-section="articles"
-    aside
+    .aside
       h2 Articles
       p These examples can be used for blog posts, articles or general text heavy content
     .bside
@@ -133,7 +133,7 @@ div role="main"
 
   hr.spacer
   .filtered-listing-section.clearfix data-section="linked-listing"
-    aside
+    .aside
       h2 Linked listings
       p Different layouts for any kind of linked listing
     .bside
@@ -169,7 +169,7 @@ div role="main"
 
   hr.spacer
   .filtered-listing-section.clearfix data-section="people"
-    aside
+    .aside
       h2 People
     .bside
       ul.filtered-listing-grid
@@ -192,7 +192,7 @@ div role="main"
 
   hr.spacer
   .filtered-listing-section.clearfix data-section="server-pages"
-    aside
+    .aside
       h2 Server pages
       p Server error, File not found, etc ...
     .bside

--- a/views/templates/no-header.slim
+++ b/views/templates/no-header.slim
@@ -36,7 +36,7 @@ div role="main"
               h3 Get HR advice
               p Find out where to go for HR advice and support.
 
-    aside.layout-sidebar__side.box
+    .aside.layout-sidebar__side.box
       h2 Popular resources
       ul
         li

--- a/views/templates/search.slim
+++ b/views/templates/search.slim
@@ -197,7 +197,7 @@ div role="main"
             p In the Plant Science major you will gain comprehensive knowledge of plant biology, from cells and molecules to evolution and the environment. You will explore ...
             p.url: a href="http://coursesearch.unimelb.edu.au/majors/34-plant-science" coursesearch.unimelb.edu.au/majors/34-plant-science
 
-    aside.layout-sidebar__side.box
+    .aside.layout-sidebar__side.box
       ul.sidebar-tabs__list role="tablist"
         li: a.sidebar-tabs__tab role="tab" aria-controls="all" aria-selected="true" href="#all" All results (809)
         li: a.sidebar-tabs__tab role="tab" aria-controls="courses" href="#courses" Courses &amp; Subjects (45)

--- a/views/templates/staff-news.slim
+++ b/views/templates/staff-news.slim
@@ -11,7 +11,7 @@ div role="main"
         .article
           h2 Outage to University websites this Sunday
           p This Sunday (22 November) between 6am and 7am, a wide range of University websites will be offline for around 30 minutes as an important upgrade takes place on the underlying infrastructure. This includes the University homepage, Staff and Student Hubs, Library, About Us and other University websites. Themis, the LMS, Student Portal and other key applications will continue to operate as normal. This time has been selected to try to minimise disruption.
-        aside
+        .aside
           div
             p.news__meta-title Source
             p Tom Stringer, Digital and Online Channels team
@@ -25,7 +25,7 @@ div role="main"
         .article
           h2  Editorial change freeze to Matrix CMS websites
           p From Monday morning 7 December to Wednesday lunchtime 9 December, an editorial change freeze will be instituted on the Matrix Content Management System (Matrix CMS) while the system is upgraded to the latest version. All CMS sites will remain available during this period, but editors and administrators will be prevented from making changes, and form submissions will be suspended. If emergency changes are required during this time, the Digital and Online Channels team will be able to assist.
-        aside
+        .aside
           div
             p.news__meta-title Source
             p Tom Stringer, Digital and Online Channels team
@@ -39,7 +39,7 @@ div role="main"
         .article
           h2 Melbourne University Family Club Co-op - Event to celebrate 50 years
           p Melbourne University Family Club Co-op is celebrating 50 years and is combining their annual Family Fun Day with this special celebration. There will be a $10 per person entry fee (children under 1 are free) which will cover food, soft drinks and all entertainment, including a jumping castle and face painting. There will be a history display showcasing the 50 years of childcare and an opportunity to reminisce with staff and old friends. All are welcome on Sunday 29 November from 10am-2pm.
-        aside
+        .aside
           div
             p.news__meta-title Source
             p Jaci Blumhagen, Project Manager, Project Services
@@ -51,7 +51,7 @@ div role="main"
             p Mandy
             p: a.news__nowrap href="tel:+61383448097" +61 3 8344 8097
 
-    aside.layout-sidebar__side.box
+    .aside.layout-sidebar__side.box
       h2 Previous Issues
       ul
         li: a href="#" Issue 583, 1 November 2015


### PR DESCRIPTION
We've found that the content in `<aside>` on production design system sites is typically a heading, and some contextual description, this does not follow the intended use [(tangential content)](http://www.w3.org/TR/html-markup/aside.html) of this element.

To avoid any risk of assistive technologies skipping the content of a semantic `<aside>`, this PR replaces all styling and documentation mentions with `<div class="aside">` instead. 

This is a breaking change!