### PR TITLE
Use consistent colour between input and textarea placeholders

### DIFF
--- a/assets/targets/components/forms/01-notes-no-source.md
+++ b/assets/targets/components/forms/01-notes-no-source.md
@@ -1,0 +1,3 @@
+<section>
+  <p class="alert-warning"><strong>Warning:</strong> Please ensure that all form inputs have an appropriate label! Never use a placeholder instead of a label.</p>
+</section>

--- a/assets/targets/components/forms/01-text-field.slim
+++ b/assets/targets/components/forms/01-text-field.slim
@@ -13,12 +13,12 @@ form method="post" action="" data-validate=""
     div
       label for="f-id"
         ' Product Code (regex pattern matching):
-      input data-pattern="[0-9][A-Z]{3}" maxlength="4" id="f-id" name="f[p_id]" type="text" data-error="Single digit followed by three uppercase letters."
+      input data-pattern="[0-9][A-Z]{3}" maxlength="4" id="f-id" name="f[p_id]" type="text" placeholder="3ABC" data-error="Single digit followed by three uppercase letters."
 
     div
       label for="f-message"
         ' Message:
-      textarea aria-required="true" id="f-message" name="f[message]" data-error="Please enter a message."
+      textarea aria-required="true" placeholder="Please enter a message" id="f-message" name="f[message]" data-error="Please enter a message."
 
   footer
     input type="submit"

--- a/assets/targets/components/forms/_forms.scss
+++ b/assets/targets/components/forms/_forms.scss
@@ -113,24 +113,6 @@
   input[type="url"] {
     @include textcontrol;
     width: 100%;
-
-    &:-moz-placeholder { // /* Mozilla Firefox 4 to 18 */
-      color: $midgray;
-      opacity: 1;
-    }
-
-    &::-moz-placeholder { // /* Mozilla Firefox 19+ */
-      color: $midgray;
-      opacity: 1;
-    }
-
-    &:-ms-input-placeholder { // /* Internet Explorer 10+ */
-      color: $midgray;
-    }
-
-    &::-webkit-input-placeholder { // /* WebKit browsers */
-      color: $midgray;
-    }
   }
 
   textarea {


### PR DESCRIPTION
Remove defined placeholder colour altogether (use browser default), add note about using labels.

Fixes #699 