### PR TITLE
Unsettled radio/checkbox controls

### DIFF
--- a/assets/targets/components/forms/11-01-notes.md
+++ b/assets/targets/components/forms/11-01-notes.md
@@ -1,0 +1,3 @@
+<section>
+  <p class="alert-info"><strong>Note:</strong> Unstyled <em>radio</em> and <em>checkbox</em> controls are now available by adding <strong>class="unstyled-controls"</strong> to the form.</p>
+</section>

--- a/assets/targets/components/forms/11-01-notes.md
+++ b/assets/targets/components/forms/11-01-notes.md
@@ -1,3 +1,3 @@
 <section>
-  <p class="alert-info"><strong>Note:</strong> Unstyled <em>radio</em> and <em>checkbox</em> controls are now available by adding <strong>class="unstyled-controls"</strong> to the form.</p>
+  <p class="alert-info"><strong>Note:</strong> Unstyled <code>radio</code> and <code>checkbox</code> controls are now available by adding <code>class="unstyled-controls"</code> to the form (1st example below), or <code>class="unstyled"</code> selectively on each <code>input</code> (2nd example below). The unstyled class is only available for <strong>radio</strong> and <strong>checkbox</strong> controls!</p>
 </section>

--- a/assets/targets/components/forms/11-02-unstyled-controls.slim
+++ b/assets/targets/components/forms/11-02-unstyled-controls.slim
@@ -1,35 +1,14 @@
 form.unstyled-controls method="post" action="" data-validate=""
   fieldset
     div
-      label for="f2-name"
-        ' Name (required):
-      input aria-required="true" id="f2-name" name="f[name]" type="text" data-error="Please enter your name."
+      legend
+        'class="unstyled-controls" on form
 
     div
-      label for="f2-email"
-        ' Email (pattern matching):
-      input data-pattern="email" id="f2-email" name="f[email]" type="email" data-error="Please enter a valid email."
-
-    div
-      label for="f2-id"
-        ' Product Code (regex pattern matching):
-      input data-pattern="[0-9][A-Z]{3}" maxlength="4" id="f2-id" name="f[p_id]" type="text" placeholder="3ABC" data-error="Single digit followed by three uppercase letters."
-
-  fieldset
-    div
-      legend Select preferred option (required):
       .inline
         input type="checkbox" id="c2-1" class="checkbox" aria-required="true" name="f2[approve]" data-error="Please select an option"
         label for="c2-1"
           span Option 1
-      .inline
-        input type="checkbox" id="c2-2" class="checkbox" aria-required="true" name="f2[approve]" data-error="Please select an option"
-        label for="c2-2"
-          span Option 2
-
-  fieldset
-    div
-      legend Make a selection (implicitly required):
       .inline
         input checked="" aria-required="true" name="f2[radio]" type="radio" id="radio-2-1" value="yes" data-error="Please make a selection"
         label for="radio-2-1"
@@ -39,10 +18,18 @@ form.unstyled-controls method="post" action="" data-validate=""
         label for="radio-2-2"
           span No
 
+form.alt method="post" action="" data-validate=""
+  fieldset
     div
-      label for="f2-message"
-        ' Message:
-      textarea aria-required="true" placeholder="Please enter a message" id="f2-message" name="f[message]" data-error="Please enter a message."
+      legend
+        'class="unstyled" on first control
 
-  footer
-    input type="submit"
+    div
+      .inline
+        input.unstyled type="checkbox" id="c3-1" class="checkbox" aria-required="true" name="f2[approve]" data-error="Please select an option"
+        label for="c3-1"
+          span Option 1
+      .inline
+        input type="checkbox" id="c3-2" class="checkbox" aria-required="true" name="f2[approve]" data-error="Please select an option"
+        label for="c3-2"
+          span Option 2

--- a/assets/targets/components/forms/11-02-unstyled-controls.slim
+++ b/assets/targets/components/forms/11-02-unstyled-controls.slim
@@ -1,0 +1,48 @@
+form.unstyled-controls method="post" action="" data-validate=""
+  fieldset
+    div
+      label for="f2-name"
+        ' Name (required):
+      input aria-required="true" id="f2-name" name="f[name]" type="text" data-error="Please enter your name."
+
+    div
+      label for="f2-email"
+        ' Email (pattern matching):
+      input data-pattern="email" id="f2-email" name="f[email]" type="email" data-error="Please enter a valid email."
+
+    div
+      label for="f2-id"
+        ' Product Code (regex pattern matching):
+      input data-pattern="[0-9][A-Z]{3}" maxlength="4" id="f2-id" name="f[p_id]" type="text" placeholder="3ABC" data-error="Single digit followed by three uppercase letters."
+
+  fieldset
+    div
+      legend Select preferred option (required):
+      .inline
+        input type="checkbox" id="c2-1" class="checkbox" aria-required="true" name="f2[approve]" data-error="Please select an option"
+        label for="c2-1"
+          span Option 1
+      .inline
+        input type="checkbox" id="c2-2" class="checkbox" aria-required="true" name="f2[approve]" data-error="Please select an option"
+        label for="c2-2"
+          span Option 2
+
+  fieldset
+    div
+      legend Make a selection (implicitly required):
+      .inline
+        input checked="" aria-required="true" name="f2[radio]" type="radio" id="radio-2-1" value="yes" data-error="Please make a selection"
+        label for="radio-2-1"
+          span Yes
+      .inline
+        input aria-required="true" name="f2[radio]" type="radio" id="radio-2-2" value="no" data-error="Please make a selection"
+        label for="radio-2-2"
+          span No
+
+    div
+      label for="f2-message"
+        ' Message:
+      textarea aria-required="true" placeholder="Please enter a message" id="f2-message" name="f[message]" data-error="Please enter a message."
+
+  footer
+    input type="submit"

--- a/assets/targets/components/forms/_forms.scss
+++ b/assets/targets/components/forms/_forms.scss
@@ -256,121 +256,115 @@
       }
     }
   }
-}
 
-.uomcontent form:not(.unstyled-controls) fieldset {
-  // exclude style from IE lt 9
   input[type="checkbox"],
   input[type="radio"] {
     display: inline;
   }
+}
 
-  @include breakpoint(0) {
-    input[type="checkbox"],
-    input[type="radio"] {
-      position: absolute !important;
-      clip: rect(1px, 1px, 1px, 1px);
+.uomcontent form:not(.unstyled-controls) fieldset {
+  input[type="checkbox"]:not(.unstyled),
+  input[type="radio"]:not(.unstyled) {
+    position: absolute !important;
+    clip: rect(1px, 1px, 1px, 1px);
 
-      & + label {
-        @include rem(margin-top, 4px);
-        @include rem(margin-bottom, -12px);
+    & + label {
+      @include rem(margin-top, 4px);
+      @include rem(margin-bottom, -12px);
+      cursor: pointer;
+      display: block;
+      position: relative;
+      width: 100%;
+
+      &::after {
+        background: transparent;
+        content: '';
+        left: 4px;
+        opacity: 0;
+        position: absolute;
+        top: 4px;
+      }
+
+      &:active::after {
+        opacity: .2;
+      }
+
+      span {
+        @include rem(padding-left, 35px);
         cursor: pointer;
         display: block;
-        position: relative;
-        width: 100%;
+        text-indent: 0;
 
-        &::after {
-          background: transparent;
+        &::before {
+          background-color: $white;
+          border: 1px solid lighten($midgray, 40%);
+          box-sizing: border-box;
           content: '';
-          left: 4px;
-          opacity: 0;
-          position: absolute;
-          top: 4px;
-        }
-
-        &:active::after {
-          opacity: .2;
-        }
-
-        span {
-          @include rem(padding-left, 35px);
-          cursor: pointer;
           display: block;
-          text-indent: 0;
-
-          &::before {
-            background-color: $white;
-            border: 1px solid lighten($midgray, 40%);
-            box-sizing: border-box;
-            content: '';
-            display: block;
-            height: 20px;
-            left: -1px;
-            margin: 0 10px -3px 1px;
-            padding: 1px;
-            position: absolute;
-            top: 0;
-            width: 20px;
-          }
+          height: 20px;
+          left: -1px;
+          margin: 0 10px -3px 1px;
+          padding: 1px;
+          position: absolute;
+          top: 0;
+          width: 20px;
         }
       }
-
-      &:checked + label {
-        &:active,
-        &::after {
-          opacity: 1;
-        }
-      }
-
-      &:focus + label span::before {
-        border-color: $highlight;
-      }
     }
 
-    input[type="checkbox"] + label {
+    &:checked + label {
+      &:active,
       &::after {
-        border: 3px solid $highlight;
-        border-right: 0 none;
-        border-top: 0 none;
-        height: 5px;
-        transform: rotate(-45deg);
-        width: 10px;
-      }
-
-      span::before {
-        border-radius: 3px;
+        opacity: 1;
       }
     }
 
-    input[type="radio"] + label {
-      &::after {
-        background-color: $highlight;
-        border-radius: 50%;
-        height: 12px;
-        width: 12px;
-      }
-
-      span::before {
-        border-radius: 50%;
-      }
-    }
-
-    .invalid input[type="checkbox"],
-    .invalid input[type="radio"] {
-      & + label + small {
-        @include rem(padding-top, 18px); // Compensate for negative bottom margin on label
-      }
+    &:focus + label span::before {
+      border-color: $highlight;
     }
   }
 
-  .align-checkbox {
-    line-height: 1.4;
+  input[type="checkbox"]:not(.unstyled) + label {
+    &::after {
+      border: 3px solid $highlight;
+      border-right: 0 none;
+      border-top: 0 none;
+      height: 5px;
+      transform: rotate(-45deg);
+      width: 10px;
+    }
 
-    @include breakpoint(0) {
-      @include rem(padding-left, 30px);
-      @include rem(text-indent, -40px);
+    span::before {
+      border-radius: 3px;
     }
   }
+
+  input[type="radio"]:not(.unstyled) + label {
+    &::after {
+      background-color: $highlight;
+      border-radius: 50%;
+      height: 12px;
+      width: 12px;
+    }
+
+    span::before {
+      border-radius: 50%;
+    }
+  }
+
+  .invalid input[type="checkbox"]:not(.unstyled),
+  .invalid input[type="radio"]:not(.unstyled) {
+    & + label + small {
+      @include rem(padding-top, 18px); // Compensate for negative bottom margin on label
+    }
+  }
+}
+
+.align-checkbox {
+  @include rem(padding-left, 30px);
+  @include rem(text-indent, -40px);
+  line-height: 1.4;
 }
 
 .uomcontent .newsletter-box {

--- a/assets/targets/components/forms/_forms.scss
+++ b/assets/targets/components/forms/_forms.scss
@@ -52,8 +52,6 @@
 }
 
 .uomcontent .form-error {
-  // @include rem(padding, 10px);
-  // background-color: rgba($warning, 0.1);
   color: $warning;
 
   p {
@@ -119,120 +117,6 @@
     @include textcontrol;
     height: 200px;
     width: 100%;
-  }
-
-  // exclude style from IE lt 9
-  input[type="checkbox"],
-  input[type="radio"] {
-    display: inline;
-  }
-
-  @include breakpoint(0) {
-    input[type="checkbox"],
-    input[type="radio"] {
-      position: absolute !important;
-      clip: rect(1px 1px 1px 1px); /* IE6, IE7 */
-      clip: rect(1px, 1px, 1px, 1px);
-
-      & + label {
-        @include rem(margin-top, 4px);
-        @include rem(margin-bottom, -12px);
-        cursor: pointer;
-        display: block;
-        position: relative;
-        width: 100%;
-
-        &::after {
-          background: transparent;
-          content: '';
-          left: 4px;
-          opacity: 0;
-          position: absolute;
-          top: 4px;
-        }
-
-        &:active::after {
-          opacity: .2;
-        }
-
-        span {
-          @include rem(padding-left, 35px);
-          cursor: pointer;
-          display: block;
-          text-indent: 0;
-
-          &::before {
-            background-color: $white;
-            border: 1px solid lighten($midgray, 40%);
-            box-sizing: border-box;
-            content: '';
-            display: block;
-            height: 20px;
-            left: -1px;
-            margin: 0 10px -3px 1px;
-            padding: 1px;
-            position: absolute;
-            top: 0;
-            width: 20px;
-          }
-        }
-      }
-
-      &:checked + label {
-        &:active,
-        &::after {
-          opacity: 1;
-        }
-      }
-
-      &:focus + label span::before {
-        border-color: $highlight;
-      }
-    }
-
-    input[type="checkbox"] + label {
-      &::after {
-        border: 3px solid $highlight;
-        border-right: 0 none;
-        border-top: 0 none;
-        height: 5px;
-        transform: rotate(-45deg);
-        width: 10px;
-      }
-
-      span::before {
-        border-radius: 3px;
-      }
-    }
-
-    input[type="radio"] + label {
-      &::after {
-        background-color: $highlight;
-        border-radius: 50%;
-        height: 12px;
-        width: 12px;
-      }
-
-      span::before {
-        border-radius: 50%;
-      }
-    }
-
-    .invalid input[type="checkbox"],
-    .invalid input[type="radio"] {
-      & + label + small {
-        @include rem(padding-top, 18px); // Compensate for negative bottom margin on label
-      }
-    }
-  }
-
-  .align-checkbox {
-    line-height: 1.4;
-
-    @include breakpoint(0) {
-      @include rem(padding-left, 30px);
-      @include rem(text-indent, -40px);
-    }
   }
 
   .inline {
@@ -370,6 +254,121 @@
           }
         }
       }
+    }
+  }
+}
+
+.uomcontent form:not(.unstyled-controls) fieldset {
+  // exclude style from IE lt 9
+  input[type="checkbox"],
+  input[type="radio"] {
+    display: inline;
+  }
+
+  @include breakpoint(0) {
+    input[type="checkbox"],
+    input[type="radio"] {
+      position: absolute !important;
+      clip: rect(1px, 1px, 1px, 1px);
+
+      & + label {
+        @include rem(margin-top, 4px);
+        @include rem(margin-bottom, -12px);
+        cursor: pointer;
+        display: block;
+        position: relative;
+        width: 100%;
+
+        &::after {
+          background: transparent;
+          content: '';
+          left: 4px;
+          opacity: 0;
+          position: absolute;
+          top: 4px;
+        }
+
+        &:active::after {
+          opacity: .2;
+        }
+
+        span {
+          @include rem(padding-left, 35px);
+          cursor: pointer;
+          display: block;
+          text-indent: 0;
+
+          &::before {
+            background-color: $white;
+            border: 1px solid lighten($midgray, 40%);
+            box-sizing: border-box;
+            content: '';
+            display: block;
+            height: 20px;
+            left: -1px;
+            margin: 0 10px -3px 1px;
+            padding: 1px;
+            position: absolute;
+            top: 0;
+            width: 20px;
+          }
+        }
+      }
+
+      &:checked + label {
+        &:active,
+        &::after {
+          opacity: 1;
+        }
+      }
+
+      &:focus + label span::before {
+        border-color: $highlight;
+      }
+    }
+
+    input[type="checkbox"] + label {
+      &::after {
+        border: 3px solid $highlight;
+        border-right: 0 none;
+        border-top: 0 none;
+        height: 5px;
+        transform: rotate(-45deg);
+        width: 10px;
+      }
+
+      span::before {
+        border-radius: 3px;
+      }
+    }
+
+    input[type="radio"] + label {
+      &::after {
+        background-color: $highlight;
+        border-radius: 50%;
+        height: 12px;
+        width: 12px;
+      }
+
+      span::before {
+        border-radius: 50%;
+      }
+    }
+
+    .invalid input[type="checkbox"],
+    .invalid input[type="radio"] {
+      & + label + small {
+        @include rem(padding-top, 18px); // Compensate for negative bottom margin on label
+      }
+    }
+  }
+
+  .align-checkbox {
+    line-height: 1.4;
+
+    @include breakpoint(0) {
+      @include rem(padding-left, 30px);
+      @include rem(text-indent, -40px);
     }
   }
 }


### PR DESCRIPTION
Refactor CSS to allow `radio` and `checkbox` controls to be unstyled for custom CMS usage, removed up old IE browser sniffing (media query).

Fixes #719 
Fixes #470 
