### PR TITLE
Fix default scrolling behaviour for sidebar tabs

### DIFF
--- a/assets/targets/components/tabs/02-sidebar-tabs.slim
+++ b/assets/targets/components/tabs/02-sidebar-tabs.slim
@@ -1,6 +1,17 @@
 p <strong>Sidebar tabs</strong> are another form of navigational tabs for use with the <strong>sidebar layout</strong>. For practical examples, have a look at the <a href="/layouts/search">search layout</a> (<a href="/layouts/search/source">view source</a>) and <a href="/layouts/course">course layout</a> (<a href="/layouts/course/source">view source</a>).
+
 p If the sidebar is on the right-hand side of the page, use class <code>sidebar-tabs--right</code> to bring the tabs against the left edge of the sidebar.
-p.alert-info <strong>Note:</strong> The sidebar layout should only ever be used as the <strong>main layout</strong> of a page, and not in the middle of a page like below.
+
+p.alert-info <strong>Note:</strong> By default, sidebar tabs are designed to scroll the page position up to a full width navigation component (above). If one does not exist on the page, it will scroll to itself. You can set a different scroll target by using a <code>data-scroll-target</code> attribute on the <code>sidebar-tabs</code> container. eg.
+
+erb:
+  <pre>
+    &lt;div class="sidebar-tabs" data-scroll-target=".some-class"&gt;
+      ...
+    &lt;/div&gt;
+  </pre>
+
+p.alert-warning <strong>Warning:</strong> The sidebar layout should only be used as the <strong>main layout</strong>, and not in the middle of a page as in the example below.
 
 .layout-sidebar.sidebar-tabs
   .aside.layout-sidebar__side.box

--- a/assets/targets/components/tabs/sidebar-tabs.js
+++ b/assets/targets/components/tabs/sidebar-tabs.js
@@ -12,7 +12,10 @@ function SidebarTabs(el, props) {
   this.props.tabs = el.querySelectorAll('.sidebar-tabs__tab');
   this.props.panels = el.querySelectorAll('.sidebar-tabs__panel');
   this.props.panelsContainer = el.querySelector('.sidebar-tabs__panels');
+
   this.props.scrollTarget = this.props.scrollTarget || this.props.panelsContainer;
+  if (this.el.hasAttribute('data-scroll-target'))
+    this.props.scrollTarget = document.querySelector(this.el.getAttribute('data-scroll-target'));
 
   var hash = window.location.hash;
   var matchFoundForHash = false;
@@ -62,9 +65,10 @@ SidebarTabs.prototype.handleTabClicked = function (tab, evt) {
 
   var prevIndex = this.props.currentIndex;
 
-  // Select the tab, show its panel, then scroll to the panels container
+  // Select the tab, show its panel, then scroll to the panels container unless data-no-scroll is set
   this.selectTab(tab, true);
-  setTimeout(this.scroll.bind(this));
+  if (!tab.hasAttribute('data-no-scroll'))
+    setTimeout(this.scroll.bind(this));
 
   // If selected tab has changed, update the page's location
   if (prevIndex !== this.props.currentIndex) {


### PR DESCRIPTION
* Add `data-scroll-target` and `data-no-scroll` hooks
* Update documentation
