### PR TITLE
Fix use of `box` helper class with sidebar layout

### DIFF
--- a/assets/targets/components/tabs/02-sidebar-tabs.slim
+++ b/assets/targets/components/tabs/02-sidebar-tabs.slim
@@ -14,8 +14,8 @@ erb:
 p.alert-warning <strong>Warning:</strong> The sidebar layout should only be used as the <strong>main layout</strong>, and not in the middle of a page as in the example below.
 
 .layout-sidebar.sidebar-tabs
-  .aside.layout-sidebar__side.box
-    .layout-sidebar__side__inner
+  .aside.layout-sidebar__side
+    .layout-sidebar__side__inner.box
       h2.subtitle Example
       p No modus albucius vis, ad duis fabellas per. Et vim viris habemus referrentur, in mei liber scaevola. Ponderum referrentur consectetuer sea eu, illud temporibus vim ei.
       ul.sidebar-tabs__list
@@ -23,8 +23,8 @@ p.alert-warning <strong>Warning:</strong> The sidebar layout should only be used
         li: a.sidebar-tabs__tab role="tab" aria-controls="side-2" href="#side-2" Tab 2
         li: a.sidebar-tabs__tab role="tab" aria-controls="side-3" href="#side-3" Tab 3
 
-  .layout-sidebar__main.sidebar-tabs__panels.box
-    .layout-sidebar__main__inner
+  .layout-sidebar__main.sidebar-tabs__panels
+    .layout-sidebar__main__inner.box
       #1side.sidebar-tabs__panel.box role="tabpanel"
         h2 Tab 1
         p Et vim viris habemus referrentur, in mei liber scaevola. Ponderum referrentur consectetuer sea eu, illud temporibus vim ei. Cu has assum consectetuer, omittam scriptorem est te. At mel verear verterem reformidans, ei sonet quodsi eripuit mei, per utinam vituperata an.

--- a/views/templates/course.slim
+++ b/views/templates/course.slim
@@ -59,8 +59,8 @@ div role="main"
 
     #course-structure.tab role="tabpanel"
       .layout-sidebar.sidebar-tabs
-        .aside.layout-sidebar__side.box
-          .layout-sidebar__side__inner
+        .aside.layout-sidebar__side
+          .layout-sidebar__side__inner.box
             h2.subtitle Degree Structure
             p The Doctor of Veterinary Medicine is four years full-time, and is delivered at the Parkville campus (Years One and Two) and at the Werribee campus (Years Three and Four).
             p The Doctor of Veterinary Medicine (DVM) can be taken in three years via the ‘accelerated pathway’ if you have a Bachelor of Science degree from the University of Melbourne with a major in Animal Health and Disease (Veterinary Bioscience specialisation) and meet the entry requirements.
@@ -68,8 +68,8 @@ div role="main"
               li: a.sidebar-tabs__tab role="tab" aria-controls="doctor-of-veterinary-medicine-4-years" aria-selected="true" href="#doctor-of-veterinary-medicine-4-years" Doctor of Veterinary Medicine  (4 years)
               li: a.sidebar-tabs__tab role="tab" aria-controls="doctor-of-veterinary-medicine-accelerated-pathway-3-years" href="#doctor-of-veterinary-medicine-accelerated-pathway-3-years" Doctor of Veterinary Medicine  - Accelerated Pathway (3 years)
 
-        .layout-sidebar__main.sidebar-tabs__panels.box
-          .layout-sidebar__main__inner
+        .layout-sidebar__main.sidebar-tabs__panels
+          .layout-sidebar__main__inner.box
             #doctor-of-veterinary-medicine-4-years.mobile-wrap.sidebar-tabs__panel.box role="tabpanel"
               h2 Doctor of Veterinary Medicine (4 years)
               table.course-progression
@@ -520,16 +520,16 @@ div role="main"
 
     #course-structure-2.tab role="tabpanel"
       .layout-sidebar.sidebar-tabs
-        .aside.layout-sidebar__side.box
-          .layout-sidebar__side__inner
+        .aside.layout-sidebar__side
+          .layout-sidebar__side__inner.box
             h2.subtitle Second sidebar tabs test
             p The Doctor of Veterinary Medicine is&nbsp; four years full-time, and is delivered at the Parkville campus (Years One and Two) and at the Werribee campus (Years Three and Four).
             ul.sidebar-tabs__list role="tablist"
               li: a.sidebar-tabs__tab role="tab" aria-controls="side-1" aria-selected="true" href="#side-1" Tab 1
               li: a.sidebar-tabs__tab role="tab" aria-controls="side-2" href="#side-2" Tab 2
 
-        .layout-sidebar__main.sidebar-tabs__panels.box
-          .layout-sidebar__main__inner
+        .layout-sidebar__main.sidebar-tabs__panels
+          .layout-sidebar__main__inner.box
             #side-1.sidebar-tabs__panel.box role="tabpanel"
               h2 Tab 1
               p Lorem ipsum
@@ -544,8 +544,8 @@ div role="main"
 
     #fees.tab role="tabpanel"
       .layout-sidebar.layout-sidebar--right
-        .layout-sidebar__main.box
-          .layout-sidebar__main__inner
+        .layout-sidebar__main
+          .layout-sidebar__main__inner.box
             h2 Fees for international graduate students
             p The course fee per year is calculated on the basis of one full-time year of study (1 EFTSL). If a course duration is less than one year, you will pay the indicative total course fee. Actual fees vary depending on the subjects you are taking. The University reviews fees annually. The indicative total course fee is based on typical subject enrolments, and includes an indexation of 5% per annum. <a href="http://futurestudents.unimelb.edu.au/admissions/fees" target="_blank">More information about tuition fees</a>.
             p If you are an international student, you may be eligible for a range of scholarships or grants.
@@ -604,8 +604,8 @@ div role="main"
               p.center
                 a.button-hero href="#apply" data-tab="6" Next : Apply now
 
-        .aside.layout-sidebar__side.box
-          .layout-sidebar__side__inner
+        .aside.layout-sidebar__side
+          .layout-sidebar__side__inner.box
             p The fees for this degree are listed below, indicative for 2015.
             .pricing
               h2 400 point program

--- a/views/templates/fake-tab.slim
+++ b/views/templates/fake-tab.slim
@@ -27,13 +27,13 @@ div role="main"
 
     #requirements.tab data-current="" role="tabpanel"
       .layout-sidebar.sidebar-tabs
-        .aside.layout-sidebar__side.box
-          .layout-sidebar__side__inner
+        .aside.layout-sidebar__side
+          .layout-sidebar__side__inner.box
             h2.subtitle 400 point program
             p 4 years full-time / part-time unavailable
 
-        .layout-sidebar__main.box
-          .layout-sidebar__main__inner
+        .layout-sidebar__main
+          .layout-sidebar__main__inner.box
             h2 Entry Requirements for applicants who are completing, or have completed, tertiary studies overseas
             p The DVM is a graduate course.&nbsp; To be eligible for selection, applicants to the DVM must have completed an undergraduate science or agriculture degree including at least one semester in biology (cellular/general) and in biochemistry.
             p International applicants who are eligible for selection will be made an offer into the DVM where they have obtained results across science/agriculture subjects at any one of the following thresholds:

--- a/views/templates/no-header.slim
+++ b/views/templates/no-header.slim
@@ -5,8 +5,8 @@ div role="main"
   .flash.flash--info.flash--keep-left
     p <strong>Success!</strong> This is an example of a flash message.
   .layout-sidebar.layout-sidebar--right
-    .layout-sidebar__main.box
-      .layout-sidebar__main__inner
+    .layout-sidebar__main
+      .layout-sidebar__main__inner.box
         h1.aligned-title Human resources
         section.lead.left
           p Leave, pay, HR advice, equity and fairness, training and development, career management and job search.
@@ -37,8 +37,8 @@ div role="main"
                 h3 Get HR advice
                 p Find out where to go for HR advice and support.
 
-    .aside.layout-sidebar__side.box
-      .layout-sidebar__side__inner
+    .aside.layout-sidebar__side
+      .layout-sidebar__side__inner.box
         h2 Popular resources
         ul
           li

--- a/views/templates/search.slim
+++ b/views/templates/search.slim
@@ -15,8 +15,8 @@ div role="main"
   .flash.flash--info.flash--center
     p <strong>Success!</strong> This is an example of a flash message.
   .layout-sidebar.layout-sidebar--right.sidebar-tabs.sidebar-tabs--right
-    .layout-sidebar__main.box.sidebar-tabs__panels
-      .layout-sidebar__main__inner
+    .layout-sidebar__main.sidebar-tabs__panels
+      .layout-sidebar__main__inner.box
         .sidebar-tabs__panel.box#all role="tabpanel"
           p.search-spelling
             a href="#"
@@ -198,8 +198,8 @@ div role="main"
               p In the Plant Science major you will gain comprehensive knowledge of plant biology, from cells and molecules to evolution and the environment. You will explore ...
               p.url: a href="http://coursesearch.unimelb.edu.au/majors/34-plant-science" coursesearch.unimelb.edu.au/majors/34-plant-science
 
-    .aside.layout-sidebar__side.box
-      .layout-sidebar__side__inner
+    .aside.layout-sidebar__side
+      .layout-sidebar__side__inner.box
         ul.sidebar-tabs__list role="tablist"
           li: a.sidebar-tabs__tab role="tab" aria-controls="all" aria-selected="true" href="#all" All results (809)
           li: a.sidebar-tabs__tab role="tab" aria-controls="courses" href="#courses" Courses &amp; Subjects (45)

--- a/views/templates/staff-news.slim
+++ b/views/templates/staff-news.slim
@@ -3,8 +3,8 @@
 div role="main"
   .headerless
   .layout-sidebar.layout-sidebar--right
-    .layout-sidebar__main.box
-      .layout-sidebar__main__inner
+    .layout-sidebar__main
+      .layout-sidebar__main__inner.box
         h1.aligned-title
           time datetime="2015-11-20"  20 November 2015
 
@@ -52,8 +52,8 @@ div role="main"
               p Mandy
               p: a.news__nowrap href="tel:+61383448097" +61 3 8344 8097
 
-    .aside.layout-sidebar__side.box
-      .layout-sidebar__side__inner
+    .aside.layout-sidebar__side
+      .layout-sidebar__side__inner.box
         h2 Previous Issues
         ul
           li: a href="#" Issue 583, 1 November 2015


### PR DESCRIPTION
The `box` helper removes the top/bottom spacing from the first/last _direct_ children only, so it has to go on `.layout-sidebar__main__inner` and `.layout-sidebar__side__inner`.