### PR TITLE
Hide 3rd party embeds at page load

### DIFF
--- a/assets/targets/components/modal/_modal.scss
+++ b/assets/targets/components/modal/_modal.scss
@@ -25,9 +25,18 @@
       max-width: 100%;
     }
 
+    // Hide accidental peek from 3rd party embeds at page load
+    iframe {
+      display: none;
+    }
+
     &.on {
       visibility: visible;
       z-index: 14;
+
+      iframe {
+        display: block;
+      }
     }
 
     @media screen and (min-width: 1100px) {


### PR DESCRIPTION
Including an iframe inside a modal (not advised anyway) can sometimes cause the iframe content to peek above page content at pageload: this PR will hide it with CSS.

Interestingly, this was caused by the bug "fix" for IE8 in v3.1 that moved the modal DOM relocation to the click event. Before then, the modals were outside the page container and couldn't peek above.
