### PR TITLE
Remove `no-js` class from localnav

### DIFF
--- a/assets/targets/components/base/_layout.scss
+++ b/assets/targets/components/base/_layout.scss
@@ -582,7 +582,7 @@ body {
 
 // Uninjected styles
 .uomcontent .page-local-history,
-.uomcontent [role="navigation"].no-js {
+.no-js .uomcontent [role="navigation"] {
   @include rem(padding, 15px 30px);
   color: $midblue;
   display: block;

--- a/assets/targets/components/base/_layout.scss
+++ b/assets/targets/components/base/_layout.scss
@@ -581,8 +581,7 @@ body {
 }
 
 // Uninjected styles
-.uomcontent .page-local-history,
-.no-js .uomcontent [role="navigation"] {
+.uomcontent .page-local-history {
   @include rem(padding, 15px 30px);
   color: $midblue;
   display: block;

--- a/assets/targets/injection/nav/_localnav.scss
+++ b/assets/targets/injection/nav/_localnav.scss
@@ -56,15 +56,6 @@
     }
   }
 
-  &.no-js {
-    @include wrapper;
-    background-color: $navy;
-    box-shadow: 0 0 0;
-    display: block;
-    position: static;
-    width: auto;
-  }
-
   .w {
     @include rem(padding-right, $width-sitemap-trigger);
     height: 100%;
@@ -233,4 +224,13 @@
       z-index: 9;
     }
   }
+}
+
+.no-js .uomcontent [role="navigation"]#sitemap {
+  @include wrapper;
+  background-color: $navy;
+  box-shadow: 0 0 0;
+  display: block;
+  position: static;
+  width: auto;
 }

--- a/assets/targets/injection/nav/localnav.es6
+++ b/assets/targets/injection/nav/localnav.es6
@@ -53,7 +53,6 @@ LocalNav.prototype.moveLocalNav = function() {
     lastli.innerHTML = '<a class="sitemap-link" href="https://unimelb.edu.au/sitemap">Browse University</a>';
     lastmenu.appendChild(lastli);
 
-    this.props.localnav.classList.remove('no-js');
     this.props.root.appendChild(this.props.localnav);
 
     var innerElements = this.props.localnav.querySelectorAll('.inner');

--- a/views/_nav.slim
+++ b/views/_nav.slim
@@ -1,5 +1,5 @@
 - unless opts[:navigation].nil? || opts[:navigation].empty?
-  div#sitemap.no-js role="navigation"
+  div#sitemap role="navigation"
     h2 Web.Unimelb
     ul
       - opts[:navigation].each do |nav_item|

--- a/views/pages/getting-started.slim.md
+++ b/views/pages/getting-started.slim.md
@@ -67,7 +67,7 @@ section
 pre: code.html
   ==convert_tags
     erb:
-      <div class="no-js" id="sitemap" role="navigation">
+      <div id="sitemap" role="navigation">
         <h2>Section title</h2>
         <ul>
           <li>
@@ -103,7 +103,7 @@ section
 pre: code.html
   ==convert_tags
     erb:
-      <div class="no-js" id="sitemap" role="navigation" data-absolute-root="/sitehome">
+      <div id="sitemap" role="navigation" data-absolute-root="/sitehome">
       ...
       </div>
 


### PR DESCRIPTION
Use global `no-js` class instead. Also, remove an unused `.no-js` selector (see commit for explanation).

### Breaking change!

The [recommended markup](https://web.unimelb.edu.au/getting-started#local-nav) for the local nav has changed: the root element with `id=sitemap` no longer needs the `no-js` class.