### PR TITLE
Fix Firefox printing issue

### DIFF
--- a/assets/shared/_normalize.scss
+++ b/assets/shared/_normalize.scss
@@ -1,14 +1,21 @@
 html,
 body {
-  height: 100%;
   margin: 0;
   padding: 0;
+}
+
+html {
+  height: 100%;
 }
 
 body {
   font-size: 1em;
   line-height: 1.5789;
   text-rendering: optimizeLegibility;
+
+  /* height of content or viewport, whichever is taller */
+  /* `height: 100%;` causes Friefox to only print the first page https://github.com/marcom-unimelb/unimelb-design-system/issues/750 */
+  min-height: 100%;
 }
 
 h1,


### PR DESCRIPTION
Fix #750 by setting `min-height` rather than `height` to 100% on body.

https://codepen.io/absolutholz/post/html-and-body-element-height-100